### PR TITLE
feature: 공통 응답/예외 구조

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ out/
 
 ### VS Code ###
 .vscode/
+
+src/main/resources/static/docs/

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,8 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.2.0'
     id 'io.spring.dependency-management' version '1.1.4'
+    id 'com.epages.restdocs-api-spec' version '0.18.2'
+    id 'org.hidetake.swagger.generator' version '2.18.2'
 }
 
 group = 'com'
@@ -24,13 +26,67 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
+
     annotationProcessor 'org.projectlombok:lombok'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'com.epages:restdocs-api-spec-mockmvc:0.18.2' // For OpenApi Wrapper
+    testImplementation 'com.epages:restdocs-api-spec-restassured:0.18.2'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-restassured'
+    testImplementation 'io.rest-assured:rest-assured:5.3.0'
+    swaggerUI 'org.webjars:swagger-ui:4.11.1'
 }
 
 tasks.named('test') {
     useJUnitPlatform()
 }
+
+
+tasks.named('jar') {
+    enabled = false
+}
+
+swaggerSources {
+    sample {
+        setInputFile(file("${buildDir}/api-spec/openapi3.yaml"))
+    }
+}
+
+openapi3 {
+    servers = [
+            { url = "http://localhost:8080"}
+    ]
+    title = "Baro API"
+    description = "Baro API Docs"
+    version = "1.0.0"
+    format = "yaml"
+}
+
+tasks.withType(GenerateSwaggerUI) {
+    dependsOn 'openapi3'
+}
+
+tasks.register('copySwaggerUI', Copy) {
+    dependsOn 'resolveMainClassName'
+    dependsOn 'generateSwaggerUISample'
+
+    def generateSwaggerUISampleTask = tasks.named('generateSwaggerUISample', GenerateSwaggerUI).get()
+
+    from("${generateSwaggerUISampleTask.outputDir}")
+    into "${buildDir}/resources/main/static/docs"
+}
+
+tasks.register('copyToLocal', Copy) {
+    dependsOn 'copySwaggerUI'
+    from("${buildDir}/resources/main/static/docs")
+    into './src/main/resources/static/docs'
+}
+
+bootJar {
+    dependsOn 'copyToLocal'
+}
+

--- a/src/main/java/com/baro/common/SimpleController1.java
+++ b/src/main/java/com/baro/common/SimpleController1.java
@@ -1,0 +1,59 @@
+package com.baro.common;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+
+@RestController
+@RequestMapping("/test1")
+public class SimpleController1 {
+    /**
+     * 그냥 Controller에서 직접 만드는 방식
+     */
+
+    @GetMapping("/ok")
+    public ResponseEntity<?> ok() {
+        return ResponseEntity.ok().build();
+        // 200
+    }
+
+    @GetMapping("/nocontent")
+    public ResponseEntity<?> noContent() {
+        return ResponseEntity.noContent().build();
+        // 204
+    }
+
+    @GetMapping("/created")
+    public ResponseEntity<?> created() {
+        return ResponseEntity.created(URI.create("/test/1")).build();
+        // 201
+    }
+
+    @GetMapping("/accepted")
+    public ResponseEntity<?> accepted() {
+        return ResponseEntity.accepted().build();
+        // 202
+    }
+
+    @GetMapping("/badrequest")
+    public ResponseEntity<?> badRequest() {
+        return ResponseEntity.badRequest().build();
+        // 400
+    }
+
+    @GetMapping("/notfound")
+    public ResponseEntity<?> notFound() {
+        return ResponseEntity.notFound().build();
+        // 404
+    }
+
+    @GetMapping("/payload")
+    public ResponseEntity<?> payloadTooLarge() {
+        return ResponseEntity.status(HttpStatus.PAYLOAD_TOO_LARGE).build();
+        // 413
+    }
+}

--- a/src/main/java/com/baro/common/SimpleController2.java
+++ b/src/main/java/com/baro/common/SimpleController2.java
@@ -1,0 +1,90 @@
+package com.baro.common;
+
+import jakarta.annotation.Nullable;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.Assert;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+
+@RestController
+@RequestMapping("/test2")
+public class SimpleController2 {
+    /**
+     * 다양한 생성자를 가진 ResponseEntity를 사용하는 방식
+     * 참고 : https://velog.io/@qotndus43/%EC%8A%A4%ED%94%84%EB%A7%81-API-%EA%B3%B5%ED%86%B5-%EC%9D%91%EB%8B%B5-%ED%8F%AC%EB%A7%B7-%EA%B0%9C%EB%B0%9C%ED%95%98%EA%B8%B0
+     */
+
+    @GetMapping("/ok")
+    public ResponseEntity<?> ok() {
+        return new ResponseEntity<>("ok", HttpStatus.OK);
+        // 200
+    }
+
+    @GetMapping("/nocontent")
+    public ResponseEntity<?> noContent() {
+        return new ResponseEntity<>("no content", HttpStatus.NO_CONTENT);
+        // 204
+    }
+
+    @GetMapping("/created")
+    public ResponseEntity<?> created() {
+        MultiValueMap<String, String> map = new HttpHeaders();
+        map.set("location", "/created/1");
+        return new ResponseEntity<>("created", map, HttpStatus.CREATED);
+        // 201
+    }
+
+    @GetMapping("/accepted")
+    public ResponseEntity<?> accepted() {
+        return new ResponseEntity<>(HttpStatus.ACCEPTED);
+        // 202
+    }
+
+    @GetMapping("/badrequest")
+    public ResponseEntity<?> badRequest() {
+        return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        // 400
+    }
+
+    @GetMapping("/notfound")
+    public ResponseEntity<?> notFound() {
+        return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        // 404
+    }
+
+    @GetMapping("/payload")
+    public ResponseEntity<?> payloadTooLarge() {
+        return new ResponseEntity<>(HttpStatus.PAYLOAD_TOO_LARGE);
+        // 413
+    }
+
+    public class ResponseEntity<T> extends HttpEntity<T> {
+
+        private final HttpStatus status;
+
+        /**
+         * 생성자 vs 빌더
+         */
+
+        public ResponseEntity(@Nullable T body, @Nullable MultiValueMap<String, String> headers, HttpStatus status) {
+            super(body, headers);
+            Assert.notNull(status, "HttpStatus must not be null");
+            this.status = status;
+        }
+
+        public ResponseEntity(HttpStatus status) {
+            this(null, null, status);
+        }
+
+        public ResponseEntity(@Nullable T body, HttpStatus status) {
+            this(body, null, status);
+        }
+    }
+}

--- a/src/main/java/com/baro/common/SimpleController3.java
+++ b/src/main/java/com/baro/common/SimpleController3.java
@@ -34,7 +34,7 @@ public class SimpleController3 {
     public ResponseEntity<?> created() {
         HttpHeaders headers = new HttpHeaders();
         headers.set("location", "/created/1");
-        return ApiReponse.successWithHeader(Responses.SUCCESS_POST_MEMO, headers);
+        return ApiReponse.success(Responses.SUCCESS_POST_MEMO, headers);
     }
 
     @GetMapping("/accepted")
@@ -49,7 +49,7 @@ public class SimpleController3 {
             return ResponseEntity.status(response.getStatus()).build();
         }
 
-        public static ResponseEntity<?> successWithHeader(Responses response, HttpHeaders headers) {
+        public static ResponseEntity<?> success(Responses response, HttpHeaders headers) {
             return ResponseEntity.status(response.getStatus()).headers(headers).body(response.getMessage());
         }
     }

--- a/src/main/java/com/baro/common/SimpleController3.java
+++ b/src/main/java/com/baro/common/SimpleController3.java
@@ -1,0 +1,90 @@
+package com.baro.common;
+
+import jakarta.annotation.Nullable;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.Assert;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/test3")
+public class SimpleController3 {
+    /**
+     * enum으로 미리 응답값을 정의해놓고, 이를 조립해서 ResponseEntity를 반환해주는 ApiResponse 객체 사용
+     */
+
+    @GetMapping("/ok")
+    public ResponseEntity<?> ok() {
+        return ApiReponse.success(Responses.SUCCESS_DELETE_MEMO);
+        // 200
+    }
+
+    @GetMapping("/nocontent")
+    public ResponseEntity<?> noContent() {
+        return ApiReponse.success(Responses.SUCCESS_NO_CONTENT);
+        // 204
+    }
+
+    @GetMapping("/created")
+    public ResponseEntity<?> created() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("location", "/created/1");
+        return ApiReponse.successWithHeader(Responses.SUCCESS_POST_MEMO, headers);
+    }
+
+    @GetMapping("/accepted")
+    public ResponseEntity<?> accepted() {
+        return ApiReponse.success(Responses.SUCCESS_ACCEPTED);
+        // 202
+    }
+
+    public class ApiReponse {
+
+        public static ResponseEntity<?> success(Responses response) {
+            return ResponseEntity.status(response.getStatus()).build();
+        }
+
+        public static ResponseEntity<?> successWithHeader(Responses response, HttpHeaders headers) {
+            return ResponseEntity.status(response.getStatus()).headers(headers).body(response.getMessage());
+        }
+    }
+
+    public enum Responses {
+
+        SUCCESS_DELETE_MEMO(HttpStatus.OK, "끄적이는 메모 삭제 성공"),
+        SUCCESS_POST_MEMO(HttpStatus.CREATED, "끄적이는 메모 업로드 성공"),
+        SUCCESS_NO_CONTENT(HttpStatus.NO_CONTENT, "content 없음"),
+        SUCCESS_ACCEPTED(HttpStatus.ACCEPTED, "accepted"),
+
+        /**
+         * header에 내용을 담는 response -> noContent, created
+         * body에 내용을 담는 response -> ok, ...
+         * 흠
+         */
+
+        ;
+
+        private HttpStatus status;
+        private String message;
+
+        Responses(HttpStatus status, String message) {
+            this.status = status;
+            this.message = message;
+        }
+
+        public HttpStatus getStatus() {
+            return status;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+    }
+
+
+}

--- a/src/main/java/com/baro/common/SimpleController4.java
+++ b/src/main/java/com/baro/common/SimpleController4.java
@@ -1,0 +1,86 @@
+package com.baro.common;
+
+import jakarta.annotation.Nullable;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.Assert;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/test4")
+public class SimpleController4 {
+
+    /**
+     * 2,3번 조합
+     */
+
+    @GetMapping("/ok")
+    public ResponseEntity<?> ok() {
+        return ApiReponse2.success(null, null, Responses.SUCCESS_DELETE_MEMO);
+        // 200
+    }
+
+    @GetMapping("/nocontent")
+    public ResponseEntity<?> noContent() {
+        return ApiReponse2.success(null, null, Responses.SUCCESS_NO_CONTENT);
+        // 204
+    }
+
+    @GetMapping("/created")
+    public ResponseEntity<?> created() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("location", "/created/1");
+        return ApiReponse2.success(headers, null, Responses.SUCCESS_POST_MEMO);
+    }
+
+    @GetMapping("/accepted")
+    public ResponseEntity<?> accepted() {
+        return ApiReponse2.success(null, null, Responses.SUCCESS_ACCEPTED);
+        // 202
+    }
+
+    public class ApiReponse2 {
+
+        public static ResponseEntity<?> success(@Nullable HttpHeaders headers, @Nullable Object body, Responses response) {
+            return ResponseEntity.status(response.getStatus()).build();
+        }
+    }
+
+    public enum Responses {
+
+        SUCCESS_DELETE_MEMO(HttpStatus.OK, "끄적이는 메모 삭제 성공"),
+        SUCCESS_POST_MEMO(HttpStatus.CREATED, "끄적이는 메모 업로드 성공"),
+        SUCCESS_NO_CONTENT(HttpStatus.NO_CONTENT, "content 없음"),
+        SUCCESS_ACCEPTED(HttpStatus.ACCEPTED, "accepted"),
+
+        /**
+         * header에 내용을 담는 response -> noContent, created
+         * body에 내용을 담는 response -> ok, ...
+         * 흠
+         */
+
+        ;
+
+        private HttpStatus status;
+        private String message;
+
+        Responses(HttpStatus status, String message) {
+            this.status = status;
+            this.message = message;
+        }
+
+        public HttpStatus getStatus() {
+            return status;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+    }
+
+}

--- a/src/main/java/com/baro/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/baro/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,18 @@
+package com.baro.common.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+class GlobalExceptionHandler {
+
+    @ExceptionHandler(value = {RequestException.class})
+    protected ResponseEntity<?> handleBadRequestException(RequestException e) {
+        log.error("handleBadRequestException throw BadRequestException : {}", e.getMessage());
+        return ApiResponse.badRequest(e.getMessage(), null);
+    }
+
+}

--- a/src/main/java/com/baro/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/baro/common/exception/GlobalExceptionHandler.java
@@ -1,6 +1,8 @@
 package com.baro.common.exception;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -11,8 +13,14 @@ class GlobalExceptionHandler {
 
     @ExceptionHandler(value = {RequestException.class})
     protected ResponseEntity<?> handleBadRequestException(RequestException e) {
-        log.error("handleBadRequestException throw BadRequestException : {}", e.getMessage());
-        return ApiResponse.badRequest(e.getMessage(), null);
+        log.info("handleRequestException throw RequestException : {}", e.exceptionType().exceptionCode());
+        return ExceptionResponse.badRequest(e.exceptionType());
     }
 
+    class ExceptionResponse {
+
+        static ResponseEntity<?> badRequest(RequestExceptionType exceptionType) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(exceptionType);
+        }
+    }
 }

--- a/src/main/java/com/baro/common/exception/LoginRequestException.java
+++ b/src/main/java/com/baro/common/exception/LoginRequestException.java
@@ -1,0 +1,25 @@
+package com.baro.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+final class LoginRequestException extends RequestException{
+    @Override
+    RequestExceptionType exceptionType() {
+        return new RequestExceptionType() {
+            @Override
+            public String exceptionCode() {
+                return "EX01";
+            }
+
+            @Override
+            public String errorMessage() {
+                return "아이디 혹은 비밀번호를 입력해주세요.";
+            }
+
+            @Override
+            public HttpStatus httpStatus() {
+                return HttpStatus.BAD_REQUEST;
+            }
+        };
+    }
+}

--- a/src/main/java/com/baro/common/exception/RequestException.java
+++ b/src/main/java/com/baro/common/exception/RequestException.java
@@ -1,0 +1,5 @@
+package com.baro.common.exception;
+
+abstract class RequestException extends RuntimeException{
+    abstract RequestExceptionType exceptionType();
+}

--- a/src/main/java/com/baro/common/exception/RequestExceptionType.java
+++ b/src/main/java/com/baro/common/exception/RequestExceptionType.java
@@ -1,0 +1,12 @@
+package com.baro.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+interface RequestExceptionType {
+
+    String exceptionCode();
+
+    String errorMessage();
+
+    HttpStatus httpStatus();
+}

--- a/src/main/java/com/baro/common/response/ApiReponse.java
+++ b/src/main/java/com/baro/common/response/ApiReponse.java
@@ -1,5 +1,0 @@
-package com.baro.common.response;
-
-// 200번대만
-public class ApiReponse {
-}

--- a/src/main/java/com/baro/common/response/ApiReponse.java
+++ b/src/main/java/com/baro/common/response/ApiReponse.java
@@ -1,0 +1,5 @@
+package com.baro.common.response;
+
+// 200번대만
+public class ApiReponse {
+}

--- a/src/test/java/com/baro/check/ActuatorTest.java
+++ b/src/test/java/com/baro/check/ActuatorTest.java
@@ -1,0 +1,37 @@
+package com.baro.check;
+
+import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.document;
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+
+import com.baro.common.RestApiDocumentationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+public class ActuatorTest extends RestApiDocumentationTest {
+
+    @Test
+    void health_check() {
+        // given
+        var url = "/actuator/health";
+
+        // when
+        var response = given(requestSpec).log().all()
+                .filter(document(DEFAULT_REST_DOCS_PATH, responseFields(
+                        fieldWithPath("status").description("상태")
+                        )))
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .header("Content-type", "application/json")
+                .when().get(url)
+                .then().log().all()
+                .extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        var message = response.body().jsonPath().getString("status");
+        assertThat(message).isEqualTo("UP");
+    }
+}

--- a/src/test/java/com/baro/common/RestApiDocumentationTest.java
+++ b/src/test/java/com/baro/common/RestApiDocumentationTest.java
@@ -20,6 +20,8 @@ import org.springframework.restdocs.RestDocumentationExtension;
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 public abstract class RestApiDocumentationTest {
 
+    protected static final String DEFAULT_REST_DOCS_PATH = "{class_name}/{method_name}";
+
     @LocalServerPort
     private int port;
 
@@ -29,6 +31,7 @@ public abstract class RestApiDocumentationTest {
     void setUp(final RestDocumentationContextProvider contextProvider) {
         RestAssured.port = port;
         requestSpec = new RequestSpecBuilder()
+                .setPort(port)
                 .addFilter(documentationConfiguration(contextProvider)
                         .operationPreprocessors()
                         .withRequestDefaults(prettyPrint())

--- a/src/test/java/com/baro/common/RestApiDocumentationTest.java
+++ b/src/test/java/com/baro/common/RestApiDocumentationTest.java
@@ -1,0 +1,38 @@
+package com.baro.common;
+
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.restassured.RestAssuredRestDocumentation.documentationConfiguration;
+
+import io.restassured.RestAssured;
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.specification.RequestSpecification;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+
+@AutoConfigureRestDocs
+@ExtendWith(RestDocumentationExtension.class)
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+public abstract class RestApiDocumentationTest {
+
+    @LocalServerPort
+    private int port;
+
+    protected RequestSpecification requestSpec;
+
+    @BeforeEach
+    void setUp(final RestDocumentationContextProvider contextProvider) {
+        RestAssured.port = port;
+        requestSpec = new RequestSpecBuilder()
+                .addFilter(documentationConfiguration(contextProvider)
+                        .operationPreprocessors()
+                        .withRequestDefaults(prettyPrint())
+                        .withResponseDefaults(prettyPrint())
+                ).build();
+    }
+}


### PR DESCRIPTION
## 관련된 이슈
#2

## 작업 사항
우선 4가지 방법 생각해봤는데요, 그중에서는 1번이 가장 낫다고 생각하고있어요
1. ResponseEntity Builder로 컨트롤러에서 직접 생성
2. 다양한 생성자를 가진 ResponseEntity를 사용하는 방식
3. enum으로 미리 응답값을 정의해놓고, 이를 조립해서 ResponseEntity를 반환해주는 ApiResponse 객체 사용
4. 2,3번 조합

1번이 가장 낫다고 생각하는 이유는,
1. 실제로 컨트롤러에서 어떤 응답값이 나가는지 빌더 인자로 직접 확인 가능 (헤더에는 뭐가 담기고, 바디에는 뭐가 담기고)
  - ResponseEntity를 만들어주는 생성자나 메서드로 따로 빼는경우 어떤 값이 헤더로 들어가고 바디로 들어가는지 명확히 알기는 어려움. 또, 메서드를 사용하는 경우 오버로딩을 사용하는 방법이 있는데, HttpStatus, Header, Body등의 유무에 따라 중복되는 네이밍의 메소드가 늘어나는 단점이 있음 
2. 사실상 나머지 방법(2,3,4)이 공통 예외 처리에서 나타나는 장점보다 크게 효과있다고 생각되지 않음

## 의논사항
- 정상 응답을 어떤 방법으로?
- 정상 응답 / 예외 응답 포맷을 동일하게? 다르게?

## 기타
X
