### PR TITLE
infra: 블루그린 무중단 배포

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -72,4 +72,4 @@ jobs:
             sudo docker pull ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.PROJECT_NAME }}:dev
             sudo chmod 777 ./deploy.sh
             sudo ./deploy.sh
-            sudo docker image prune -f
+            sudo docker image prune -af

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,4 +1,5 @@
 name: Deploy to develop
+
 on:
   push:
     branches: [ develop ]
@@ -40,6 +41,27 @@ jobs:
           file: ./Dockerfile
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.PROJECT_NAME }}:dev
 
+      - name: Send docker-compose.yml
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ secrets.NCP_HOST }}
+          username: ${{ secrets.NCP_USERNAME }}
+          password: ${{ secrets.NCP_PASSWORD }}
+          port: 22
+          source: "./docker-compose.yml"
+          target: "/root"
+
+      - name: Send deploy.sh
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ secrets.NCP_HOST }}
+          username: ${{ secrets.NCP_USERNAME }}
+          password: ${{ secrets.NCP_PASSWORD }}
+          port: 22
+          source: "./script/deploy.sh"
+          target: "/root"
+          strip_components: 2
+
       - name: Deploy
         uses: appleboy/ssh-action@master
         with:
@@ -47,13 +69,7 @@ jobs:
           username: ${{ secrets.NCP_USERNAME }}
           password: ${{ secrets.NCP_PASSWORD }}
           script: |
-            sudo docker kill ${{ secrets.PROJECT_NAME }}
-            sudo docker rm -f ${{ secrets.PROJECT_NAME }}
-            sudo docker rmi ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.PROJECT_NAME }}:dev
             sudo docker pull ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.PROJECT_NAME }}:dev
-            
-            docker run -p ${{ secrets.SERVER_PORT }}:${{ secrets.SERVER_PORT }} \
-            --name ${{ secrets.PROJECT_NAME }} \
-            -v ${{ secrets.ACCESS_LOG_DIR }}:/logs \
-            -e SPRING_PROFILES_ACTIVE=dev \
-            -d ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.PROJECT_NAME }}:dev
+            sudo chmod 777 ./deploy.sh
+            sudo ./deploy.sh
+            sudo docker image prune -f

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -41,6 +41,27 @@ jobs:
           file: ./Dockerfile
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.PROJECT_NAME }}:prod
 
+      - name: Send docker-compose.yml
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ secrets.AWS_HOST }}
+          username: ${{ secrets.EC2_USERNAME }}
+          key: ${{ secrets.AWS_SSH_KEY }}
+          port: 22
+          source: "./docker-compose.yml"
+          target: "/home/ubuntu"
+
+      - name: Send deploy.sh
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ secrets.AWS_HOST }}
+          username: ${{ secrets.EC2_USERNAME }}
+          key: ${{ secrets.AWS_SSH_KEY }}
+          port: 22
+          source: "./script/deploy.sh"
+          target: "/home/ubuntu"
+          strip_components: 2
+
       - name: Deploy
         uses: appleboy/ssh-action@master
         with:
@@ -48,12 +69,7 @@ jobs:
           username: ${{ secrets.EC2_USERNAME }}
           key: ${{ secrets.AWS_SSH_KEY }}
           script: |
-            sudo docker kill ${{ secrets.PROJECT_NAME }}
-            sudo docker rm -f ${{ secrets.PROJECT_NAME }}
-            sudo docker rmi ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.PROJECT_NAME }}:prod
             sudo docker pull ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.PROJECT_NAME }}:prod
-            
-            sudo docker run -p ${{ secrets.SERVER_PORT }}:${{ secrets.SERVER_PORT }} \
-            --name ${{ secrets.PROJECT_NAME }} \
-            -v ${{ secrets.ACCESS_LOG_DIR }}:/app/logs \
-            -d ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.PROJECT_NAME }}:prod
+            sudo chmod 777 ./deploy.sh
+            sudo ./deploy.sh
+            sudo docker image prune -f

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -72,4 +72,4 @@ jobs:
             sudo docker pull ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.PROJECT_NAME }}:prod
             sudo chmod 777 ./deploy.sh
             sudo ./deploy.sh
-            sudo docker image prune -f
+            sudo docker image prune -af

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM openjdk:17
 
-EXPOSE 8080
-
 ARG JAR_FILE=build/libs/baro-0.0.1-SNAPSHOT.jar
 
 ADD ${JAR_FILE} baro.jar

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3'
+services:
+  baro-green:
+    container_name: ${PROJECT_NAME}-green
+    image: ${DOCKERHUB_USERNAME}/${PROJECT_NAME}:${SERVER_ENVIRONMENT}
+    profiles:
+      - green
+    ports:
+      - "8080:8080"
+    env_file:
+      - .env
+  baro-blue:
+    container_name: ${PROJECT_NAME}-blue
+    image: ${DOCKERHUB_USERNAME}/${PROJECT_NAME}:${SERVER_ENVIRONMENT}
+    profiles:
+      - blue
+    ports:
+      - "8081:8080"
+    env_file:
+      - .env

--- a/script/deploy.sh
+++ b/script/deploy.sh
@@ -7,13 +7,17 @@ if [ -z "$IS_GREEN" ]; then
 
   BEFORE_COMPOSE_COLOR="blue"
   AFTER_COMPOSE_COLOR="green"
+
+  sudo sed -i 's/$backend_port 8081/$backend_port 8080/' /etc/nginx/sites-available/default
 else
   echo "green -> blue"
-    docker rm baro-blue
-    docker-compose --profile blue -p baro-blue -f docker-compose.yml up -d
+  docker rm baro-blue
+  docker-compose --profile blue -p baro-blue -f docker-compose.yml up -d
 
-    BEFORE_COMPOSE_COLOR="green"
-    AFTER_COMPOSE_COLOR="blue"
+  BEFORE_COMPOSE_COLOR="green"
+  AFTER_COMPOSE_COLOR="blue"
+
+  sudo sed -i 's/$backend_port 8080/$backend_port 8081/' /etc/nginx/sites-available/default
 fi
 
 while true
@@ -22,7 +26,6 @@ do
 
   EXIST_AFTER=$(docker-compose -p baro-${AFTER_COMPOSE_COLOR} -f docker-compose.yml ps | grep Up)
   if [ -n "$EXIST_AFTER" ]; then
-    cp /etc/nginx/nginx.${AFTER_COMPOSE_COLOR}.conf /etc/nginx/nginx.conf
     nginx -s reload
 
     docker-compose -p baro-${BEFORE_COMPOSE_COLOR} stop

--- a/script/deploy.sh
+++ b/script/deploy.sh
@@ -1,0 +1,32 @@
+IS_GREEN=$(docker-compose -p baro-green -f docker-compose.yml ps | grep Up)
+
+if [ -z "$IS_GREEN" ]; then
+  echo "blue -> green"
+  docker rm baro-green
+  docker-compose --profile green -p baro-green -f docker-compose.yml up -d
+
+  BEFORE_COMPOSE_COLOR="blue"
+  AFTER_COMPOSE_COLOR="green"
+else
+  echo "green -> blue"
+    docker rm baro-blue
+    docker-compose --profile blue -p baro-blue -f docker-compose.yml up -d
+
+    BEFORE_COMPOSE_COLOR="green"
+    AFTER_COMPOSE_COLOR="blue"
+fi
+
+while true
+do
+  sleep 3
+
+  EXIST_AFTER=$(docker-compose -p baro-${AFTER_COMPOSE_COLOR} -f docker-compose.yml ps | grep Up)
+  if [ -n "$EXIST_AFTER" ]; then
+    cp /etc/nginx/nginx.${AFTER_COMPOSE_COLOR}.conf /etc/nginx/nginx.conf
+    nginx -s reload
+
+    docker-compose -p baro-${BEFORE_COMPOSE_COLOR} stop
+    echo "$BEFORE_COMPOSE_COLOR down"
+    break
+  fi
+done;


### PR DESCRIPTION
## 관련된 이슈
- close #11

## 작업 사항
<img width="770" alt="image" src="https://github.com/YAPP-Github/23rd-Web-Team-2-BE/assets/69676101/27e1e295-ce5c-4935-ba17-0bc4b2c91a36">

- 블루그린 무중단 배포 설정
- `docker-compose.yml`
  - `${PROJECT_NAME}`, `${DOCKERHUB_USERNAME}`, `${SERVER_ENVIRONMENT}` 등의 환경변수는 각 ec2,ncp의 디폴트 루트내에 .env파일로 정의해두었습니다.
- `Dockerfile`
  - EXPOSE 8080을 제거하였습니다.
- `deploy.sh`
  - green 컨테이너가 떠있으면 blue를 띄운 후 green을 멈추고, blue 컨테이너가 떠있으면 green을 띄운 후 blue를 멈추는 로직을 추가하였습니다.
- `deploy.dev(prod).yml`
  - 기존에 container를 run시키는 로직을 전부 deploy.sh에게 넘겨서 무중단 로직을 수행하도록 변경하였습니다.
- submodule에 `application.yml`
  - shutdown시 graceful하게 종료되도록 하는 옵션을 추가하였습니다.
  - graceful하게 shutdown할 때 데드락 등의 에러로 shutdown이 계속 되지 않는 경우, 30초가 넘으면 자동으로 종료되도록 하는 옵션을 추가하였습니다.

## 기타
- 작업 내용 세부 문서 작성
  - [노션 블로그](https://valley-fog-37a.notion.site/78d286c034fc4907bb56ac5382b99dae?pvs=4)에 세부적인 설명을 문서화 했습니당
- 현재는 docker container들이 port로 Open되어있어서 인바운드로 80번 포트 말고도 8080포트가 열려있으면 8080으로도 접근 가능한데요, nginx를 도커 컨테이너로 띄운 후 80번 포트만 외부에 오픈한 뒤, api container는 expose로 도커 컨테이너로만 접근 가능하게 구현할 수 있을것같아요! 추후에 구현해보겠습니다
