### PR TITLE
feat: 회원 도메인 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,12 +55,17 @@ tasks.named('compileJava') {
     inputs.files(tasks.named('processResources'))
 }
 
-processResources.dependsOn('copySecret')
+processResources.dependsOn('copySecret', 'copyFlyway')
 
 tasks.register('copySecret', Copy) {
     from './submodule'
     include "application*.yml"
     into './src/main/resources/'
+}
+
+tasks.register('copyFlyway', Copy) {
+    from './submodule/flyway'
+    into './src/main/resources/flyway/'
 }
 
 ext.profile = (!project.hasProperty('profile') || !profile) ? 'dev' : profile

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'io.netty:netty-resolver-dns-native-macos:4.1.68.Final:osx-aarch_64'
 
+    implementation 'org.flywaydb:flyway-core'
+    implementation 'org.flywaydb:flyway-mysql'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/baro/common/config/JpaAuditingConfig.java
+++ b/src/main/java/com/baro/common/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.baro.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/main/java/com/baro/common/entity/BaseEntity.java
+++ b/src/main/java/com/baro/common/entity/BaseEntity.java
@@ -9,6 +9,7 @@ import jakarta.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
@@ -23,4 +24,7 @@ public class BaseEntity {
 
     @CreatedDate
     private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/baro/common/entity/BaseEntity.java
+++ b/src/main/java/com/baro/common/entity/BaseEntity.java
@@ -1,10 +1,6 @@
 package com.baro.common.entity;
 
-import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
 import lombok.Getter;
@@ -16,11 +12,6 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public class BaseEntity {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(updatable = false, nullable = false, columnDefinition = "BIGINT UNSIGNED")
-    private Long id;
 
     @CreatedDate
     private LocalDateTime createdAt;

--- a/src/main/java/com/baro/common/entity/BaseEntity.java
+++ b/src/main/java/com/baro/common/entity/BaseEntity.java
@@ -1,0 +1,26 @@
+package com.baro.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(updatable = false, nullable = false, columnDefinition = "BIGINT UNSIGNED")
+    private Long id;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/baro/member/domain/Member.java
+++ b/src/main/java/com/baro/member/domain/Member.java
@@ -1,0 +1,40 @@
+package com.baro.member.domain;
+
+import com.baro.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(uniqueConstraints = @UniqueConstraint(
+        name = "UK_oauth_id_oauth_service_type",
+        columnNames = {"oAuthId", "oAuthServiceType"}
+))
+@Entity
+public class Member extends BaseEntity {
+
+    @Column(nullable = false)
+    private String name;
+    @Column(nullable = false)
+    private String email;
+    private String nickname;
+    private String profileImageUrl;
+    @Column(nullable = false)
+    private String oAuthId;
+    @Column(nullable = false)
+    private String oAuthServiceType;
+
+    @Builder
+    public Member(String name, String email, String oAuthId, String oAuthServiceType) {
+        this.name = name;
+        this.email = email;
+        this.oAuthId = oAuthId;
+        this.oAuthServiceType = oAuthServiceType;
+    }
+}

--- a/src/main/java/com/baro/member/domain/Member.java
+++ b/src/main/java/com/baro/member/domain/Member.java
@@ -3,14 +3,19 @@ package com.baro.member.domain;
 import com.baro.common.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(uniqueConstraints = @UniqueConstraint(
         name = "UK_oauth_id_oauth_service_type",
@@ -19,6 +24,10 @@ import lombok.NoArgsConstructor;
 @Entity
 public class Member extends BaseEntity {
 
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(updatable = false, nullable = false, columnDefinition = "BIGINT UNSIGNED")
+    private Long id;
     @Column(nullable = false)
     private String name;
     @Column(nullable = false)
@@ -32,6 +41,14 @@ public class Member extends BaseEntity {
 
     @Builder
     public Member(String name, String email, String oAuthId, String oAuthServiceType) {
+        this.name = name;
+        this.email = email;
+        this.oAuthId = oAuthId;
+        this.oAuthServiceType = oAuthServiceType;
+    }
+
+    public Member(Long id, String name, String email, String oAuthId, String oAuthServiceType) {
+        this.id = id;
         this.name = name;
         this.email = email;
         this.oAuthId = oAuthId;

--- a/src/main/java/com/baro/member/domain/MemberRepository.java
+++ b/src/main/java/com/baro/member/domain/MemberRepository.java
@@ -1,0 +1,6 @@
+package com.baro.member.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/java/com/baro/member/domain/MemberRepository.java
+++ b/src/main/java/com/baro/member/domain/MemberRepository.java
@@ -1,11 +1,13 @@
 package com.baro.member.domain;
 
+import java.util.List;
 import java.util.Optional;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
-public interface MemberRepository extends JpaRepository<Member, Long> {
+public interface MemberRepository {
 
-    @Query("SELECT m FROM Member m WHERE m.oAuthId = :oAuthId AND m.oAuthServiceType = :oAuthServiceType")
     Optional<Member> findByOAuthIdAndOAuthServiceType(String oAuthId, String oAuthServiceType);
+
+    Member save(Member member);
+
+    List<Member> findAll();
 }

--- a/src/main/java/com/baro/member/domain/MemberRepository.java
+++ b/src/main/java/com/baro/member/domain/MemberRepository.java
@@ -1,6 +1,11 @@
 package com.baro.member.domain;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    @Query("SELECT m FROM Member m WHERE m.oAuthId = :oAuthId AND m.oAuthServiceType = :oAuthServiceType")
+    Optional<Member> findByOAuthIdAndOAuthServiceType(String oAuthId, String oAuthServiceType);
 }

--- a/src/main/java/com/baro/member/infrastructure/MemberJpaRepository.java
+++ b/src/main/java/com/baro/member/infrastructure/MemberJpaRepository.java
@@ -1,0 +1,12 @@
+package com.baro.member.infrastructure;
+
+import com.baro.member.domain.Member;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface MemberJpaRepository extends JpaRepository<Member, Long> {
+
+    @Query("SELECT m FROM Member m WHERE m.oAuthId = :oAuthId AND m.oAuthServiceType = :oAuthServiceType")
+    Optional<Member> findByOAuthIdAndOAuthServiceType(String oAuthId, String oAuthServiceType);
+}

--- a/src/main/java/com/baro/member/infrastructure/MemberRepositoryImpl.java
+++ b/src/main/java/com/baro/member/infrastructure/MemberRepositoryImpl.java
@@ -1,0 +1,30 @@
+package com.baro.member.infrastructure;
+
+import com.baro.member.domain.Member;
+import com.baro.member.domain.MemberRepository;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class MemberRepositoryImpl implements MemberRepository {
+
+    private final MemberJpaRepository memberJpaRepository;
+
+    @Override
+    public Optional<Member> findByOAuthIdAndOAuthServiceType(String oAuthId, String oAuthServiceType) {
+        return memberJpaRepository.findByOAuthIdAndOAuthServiceType(oAuthId, oAuthServiceType);
+    }
+
+    @Override
+    public Member save(Member member) {
+        return memberJpaRepository.save(member);
+    }
+
+    @Override
+    public List<Member> findAll() {
+        return memberJpaRepository.findAll();
+    }
+}

--- a/src/main/java/com/baro/oauth/application/dto/OAuthMemberInfo.java
+++ b/src/main/java/com/baro/oauth/application/dto/OAuthMemberInfo.java
@@ -2,7 +2,8 @@ package com.baro.oauth.application.dto;
 
 public record OAuthMemberInfo(
         String oAuthId,
-        String nickname
+        String name,
+        String email
         // TODO: User 설계에 따라 필드 추가
 ) {
 }

--- a/src/main/java/com/baro/oauth/infra/kakao/dto/KakaoMemberResponse.java
+++ b/src/main/java/com/baro/oauth/infra/kakao/dto/KakaoMemberResponse.java
@@ -15,7 +15,8 @@ public record KakaoMemberResponse(
     public OAuthMemberInfo toOAuthMemberInfo() {
         return new OAuthMemberInfo(
                 String.valueOf(id),
-                properties.nickname
+                properties.nickname,
+                "email" //TODO: 비즈앱 전환후 email 추가
         );
     }
 

--- a/src/test/java/com/baro/member/fake/FakeMemberRepository.java
+++ b/src/test/java/com/baro/member/fake/FakeMemberRepository.java
@@ -1,0 +1,46 @@
+package com.baro.member.fake;
+
+import com.baro.member.domain.Member;
+import com.baro.member.domain.MemberRepository;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class FakeMemberRepository implements MemberRepository {
+
+    private final AtomicLong id = new AtomicLong(0);
+    private final Map<Long, Member> members = new ConcurrentHashMap<>();
+
+    @Override
+    public Optional<Member> findByOAuthIdAndOAuthServiceType(String oAuthId, String oAuthServiceType) {
+        return members.values().stream()
+                .filter(member -> member.getOAuthId().equals(oAuthId)
+                        && member.getOAuthServiceType().equals(oAuthServiceType))
+                .findAny();
+    }
+
+    @Override
+    public Member save(Member member) {
+        if (Objects.isNull(member.getId())) {
+            Member newMember = new Member(
+                    id.getAndIncrement(),
+                    member.getName(),
+                    member.getEmail(),
+                    member.getOAuthId(),
+                    member.getOAuthServiceType()
+            );
+            members.put(newMember.getId(), newMember);
+            return newMember;
+        }
+        members.put(member.getId(), member);
+        return member;
+    }
+
+    @Override
+    public List<Member> findAll() {
+        return List.copyOf(members.values());
+    }
+}

--- a/src/test/java/com/baro/oauth/application/OAuthServiceTest.java
+++ b/src/test/java/com/baro/oauth/application/OAuthServiceTest.java
@@ -6,7 +6,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
 import com.baro.member.domain.Member;
-import com.baro.member.domain.MemberRepository;
+import com.baro.member.infrastructure.MemberJpaRepository;
 import com.baro.oauth.application.dto.OAuthMemberInfo;
 import com.baro.oauth.application.dto.OAuthTokenInfo;
 import java.util.List;
@@ -29,7 +29,7 @@ class OAuthServiceTest {
     @Autowired
     private OAuthService oAuthService;
     @Autowired
-    private MemberRepository memberRepository;
+    private MemberJpaRepository memberRepository;
 
     @MockBean
     private OAuthClientComponents components;

--- a/src/test/java/com/baro/oauth/application/OAuthServiceTest.java
+++ b/src/test/java/com/baro/oauth/application/OAuthServiceTest.java
@@ -1,0 +1,80 @@
+package com.baro.oauth.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import com.baro.member.domain.Member;
+import com.baro.member.domain.MemberRepository;
+import com.baro.oauth.application.dto.OAuthMemberInfo;
+import com.baro.oauth.application.dto.OAuthTokenInfo;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.transaction.annotation.Transactional;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+@Transactional
+@SpringBootTest(webEnvironment = WebEnvironment.NONE)
+class OAuthServiceTest {
+
+    @Autowired
+    private OAuthService oAuthService;
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @MockBean
+    private OAuthClientComponents components;
+
+    @BeforeEach
+    void setUpOAuthClientRequest() {
+        OAuthClient kakaoOAuthClient = mock(OAuthClient.class);
+        given(components.getClient(any())).willReturn(kakaoOAuthClient);
+        OAuthTokenInfo oAuthTokenInfo = new OAuthTokenInfo("accessToken", "refreshToken", 1000);
+        given(kakaoOAuthClient.requestAccessToken("kakaoAuthCode")).willReturn(oAuthTokenInfo);
+        OAuthMemberInfo oAuthMemberInfo = new OAuthMemberInfo("kakaoId", "kakaoName", "kakaoEmail");
+        given(kakaoOAuthClient.requestMemberInfo(oAuthTokenInfo)).willReturn(oAuthMemberInfo);
+    }
+
+    @Test
+    void 최초_소셜_로그인시_회원을_추가_한다() {
+        // given
+        String oAuthServiceType = "kakao";
+        String authCode = "kakaoAuthCode";
+
+        // when
+        oAuthService.signIn(oAuthServiceType, authCode);
+
+        // then
+        List<Member> members = memberRepository.findAll();
+        assertThat(members).hasSize(1);
+    }
+
+    @Test
+    void 이미_존재_하는_회원인_경우_추가_절차_없이_로그인_처리_한다() {
+        // given
+        memberRepository.save(Member.builder()
+                .name("kakaoName")
+                .email("kakaoEmail")
+                .oAuthId("kakaoId")
+                .oAuthServiceType("kakao")
+                .build());
+        String oAuthServiceType = "kakao";
+        String authCode = "kakaoAuthCode";
+
+        // when
+        oAuthService.signIn(oAuthServiceType, authCode);
+
+        // then
+        List<Member> members = memberRepository.findAll();
+        assertThat(members).hasSize(1);
+    }
+}

--- a/src/test/java/com/baro/oauth/application/OAuthServiceTest.java
+++ b/src/test/java/com/baro/oauth/application/OAuthServiceTest.java
@@ -1,47 +1,32 @@
 package com.baro.oauth.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
 
 import com.baro.member.domain.Member;
-import com.baro.member.infrastructure.MemberJpaRepository;
-import com.baro.oauth.application.dto.OAuthMemberInfo;
-import com.baro.oauth.application.dto.OAuthTokenInfo;
+import com.baro.member.domain.MemberRepository;
+import com.baro.member.fake.FakeMemberRepository;
+import com.baro.oauth.fake.FakeKakaoOAuthClient;
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.transaction.annotation.Transactional;
 
 @DisplayNameGeneration(ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
-@Transactional
-@SpringBootTest(webEnvironment = WebEnvironment.NONE)
 class OAuthServiceTest {
 
-    @Autowired
     private OAuthService oAuthService;
-    @Autowired
-    private MemberJpaRepository memberRepository;
 
-    @MockBean
-    private OAuthClientComponents components;
+    private final MemberRepository memberRepository = new FakeMemberRepository();
 
     @BeforeEach
     void setUpOAuthClientRequest() {
-        OAuthClient kakaoOAuthClient = mock(OAuthClient.class);
-        given(components.getClient(any())).willReturn(kakaoOAuthClient);
-        OAuthTokenInfo oAuthTokenInfo = new OAuthTokenInfo("accessToken", "refreshToken", 1000);
-        given(kakaoOAuthClient.requestAccessToken("kakaoAuthCode")).willReturn(oAuthTokenInfo);
-        OAuthMemberInfo oAuthMemberInfo = new OAuthMemberInfo("kakaoId", "kakaoName", "kakaoEmail");
-        given(kakaoOAuthClient.requestMemberInfo(oAuthTokenInfo)).willReturn(oAuthMemberInfo);
+        OAuthClient fakeKakaoOAuthClient = new FakeKakaoOAuthClient();
+        OAuthClientComponents components = new OAuthClientComponents(Set.of(fakeKakaoOAuthClient));
+
+        oAuthService = new OAuthService(components, memberRepository);
     }
 
     @Test

--- a/src/test/java/com/baro/oauth/fake/FakeKakaoOAuthClient.java
+++ b/src/test/java/com/baro/oauth/fake/FakeKakaoOAuthClient.java
@@ -1,0 +1,28 @@
+package com.baro.oauth.fake;
+
+import com.baro.oauth.application.OAuthClient;
+import com.baro.oauth.application.dto.OAuthMemberInfo;
+import com.baro.oauth.application.dto.OAuthTokenInfo;
+import com.baro.oauth.domain.OAuthServiceType;
+
+public class FakeKakaoOAuthClient implements OAuthClient {
+    @Override
+    public String getSignInUrl() {
+        return null;
+    }
+
+    @Override
+    public OAuthServiceType getOAuthService() {
+        return OAuthServiceType.KAKAO;
+    }
+
+    @Override
+    public OAuthTokenInfo requestAccessToken(final String code) {
+        return new OAuthTokenInfo("accessToken", "refreshToken", 1000);
+    }
+
+    @Override
+    public OAuthMemberInfo requestMemberInfo(final OAuthTokenInfo oAuthTokenInfo) {
+        return new OAuthMemberInfo("kakaoId", "kakaoName", "kakaoEmail");
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -15,3 +15,6 @@ spring:
         format_sql: true
         use_sql_comments: true
         highlight_sql: true
+
+    hibernate:
+      ddl-auto: create


### PR DESCRIPTION
## 관련된 이슈
- BAR-52 회원 도메인 추가

## 작업 사항
- RDS내 dev/prod db 분리
- Flyway 적용 (a3a31280e002d66986c7c05f504c81fb49a5c9b1, 2c30c34ac8f58fdee8c37f26779b9515539bc979)
Member 스키마에 대해 정의해두었습니다.
- Member 도메인 추가
- 소셜 로그인 후, 기존 로그인 여부에 따라 회원 추가 로직 작성

## 기타
- `MemberRepository`에 메서드를 @Query를 통해 직접 선언해두었습니다.
query methods를 활용할 때, `oAuthId`, `oAuthServerType` 처럼 한단어로 시작하는 변수에 대해서 이슈가 있더라고요.
관련 이슈 첨부해두겠습니다!
- https://github.com/spring-projects/spring-data-commons/issues/2016


- 회원 추가에 대한 관심사만 작성하였는데요. 다음 티켓에서 인증 방식(토큰이 될 것 같네요)선정 후 가입/로그인 플로우를 완성해두겠습니다!
