### PR TITLE
hotfix: 볼륨 설정 수정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     ports:
       - "8080:8080"
     volumes:
-      - ${ACCESS_LOG_DIR}:/logs
+      - access-log:/logs
     env_file:
       - .env
   baro-blue:
@@ -19,6 +19,14 @@ services:
     ports:
       - "8081:8080"
     volumes:
-      - ${ACCESS_LOG_DIR}:/logs
+      - access-log:/logs
     env_file:
       - .env
+
+volumes:
+  access-log:
+    driver: local
+    driver_opts:
+      type: none
+      device: ./access-log
+      o: bind


### PR DESCRIPTION
## 작업 사항
- 두 컨테이너가 동일한 볼륨을 공유하도록 설정하는 방식으로 사용하였습니다.
- access-log라는 이름의 볼륨을 추가하고, 해당 볼륨 컨테이너를 호스트의 `./access-log`와 mount하여 두 컨테이너(blue, green)가 공유할 수 있도록 구성하였습니다

## 기타
- https://tobelinuxer.tistory.com/87
- https://medium.com/dtevangelist/docker-%EA%B8%B0%EB%B3%B8-5-8-volume%EC%9D%84-%ED%99%9C%EC%9A%A9%ED%95%9C-data-%EA%B4%80%EB%A6%AC-9a9ac1db978c
