### PR TITLE
feat: Aws S3 연결 및 이미지 업로더 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,9 @@ dependencies {
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-mysql'
 
+    implementation platform('software.amazon.awssdk:bom:2.15.0')
+    implementation 'software.amazon.awssdk:s3control'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/baro/common/client/ImageUploader.java
+++ b/src/main/java/com/baro/common/client/ImageUploader.java
@@ -1,8 +1,0 @@
-package com.baro.common.client;
-
-import org.springframework.web.multipart.MultipartFile;
-
-public interface ImageUploader {
-
-    void upload(MultipartFile file);
-}

--- a/src/main/java/com/baro/common/client/ImageUploader.java
+++ b/src/main/java/com/baro/common/client/ImageUploader.java
@@ -1,0 +1,8 @@
+package com.baro.common.client;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface ImageUploader {
+
+    void upload(MultipartFile file);
+}

--- a/src/main/java/com/baro/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/baro/common/exception/GlobalExceptionHandler.java
@@ -2,9 +2,11 @@ package com.baro.common.exception;
 
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 @Slf4j
 @RestControllerAdvice
@@ -15,6 +17,12 @@ class GlobalExceptionHandler {
         log.warn("[handleRequestException throw RequestException : {}", e.getMessage());
         RequestExceptionType exceptionType = e.exceptionType();
         return ResponseEntity.status(exceptionType.httpStatus()).body(exceptionType.errorMessage());
+    }
+
+    @ExceptionHandler(value = {MaxUploadSizeExceededException.class})
+    public ResponseEntity<String> fileSizeLimitExceeded(MaxUploadSizeExceededException e) {
+        log.warn("[handleRequestException throw MaxUploadSizeExceededException : {}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.PAYLOAD_TOO_LARGE).body("File size limit exceeded");
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/baro/common/image/ImageUploadException.java
+++ b/src/main/java/com/baro/common/image/ImageUploadException.java
@@ -1,0 +1,8 @@
+package com.baro.common.image;
+
+public class ImageUploadException extends RuntimeException {
+
+    public ImageUploadException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/baro/common/image/ImageUploader.java
+++ b/src/main/java/com/baro/common/image/ImageUploader.java
@@ -1,0 +1,9 @@
+package com.baro.common.image;
+
+import com.baro.common.image.dto.ImageUploadResult;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface ImageUploader {
+
+    ImageUploadResult upload(MultipartFile file);
+}

--- a/src/main/java/com/baro/common/image/dto/ImageUploadResult.java
+++ b/src/main/java/com/baro/common/image/dto/ImageUploadResult.java
@@ -1,0 +1,6 @@
+package com.baro.common.image.dto;
+
+public record ImageUploadResult(
+        String key
+) {
+}

--- a/src/main/java/com/baro/common/infra/aws/s3/AwsImageUploader.java
+++ b/src/main/java/com/baro/common/infra/aws/s3/AwsImageUploader.java
@@ -1,6 +1,8 @@
 package com.baro.common.infra.aws.s3;
 
 import com.baro.common.client.ImageUploader;
+import com.baro.common.utils.ImageExtensionConverter;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Objects;
 import java.util.UUID;
@@ -29,8 +31,12 @@ public class AwsImageUploader implements ImageUploader {
                     .contentDisposition("inline")
                     .build();
 
-            RequestBody requestBody = RequestBody.fromInputStream(file.getInputStream(), file.getSize());
+            byte[] jpegImageBytes = ImageExtensionConverter.toJpeg(file);
+            ByteArrayInputStream inputStream = new ByteArrayInputStream(jpegImageBytes);
+            RequestBody requestBody = RequestBody.fromInputStream(inputStream, jpegImageBytes.length);
+
             s3Client.putObject(putObjectRequest, requestBody);
+            inputStream.close();
         } catch (IOException ioException) {
             throw new RuntimeException(ioException); //TODO: custom exception 으로 수정
         }

--- a/src/main/java/com/baro/common/infra/aws/s3/AwsImageUploader.java
+++ b/src/main/java/com/baro/common/infra/aws/s3/AwsImageUploader.java
@@ -1,5 +1,6 @@
 package com.baro.common.infra.aws.s3;
 
+import com.baro.common.image.ImageUploadException;
 import com.baro.common.image.ImageUploader;
 import com.baro.common.image.dto.ImageUploadResult;
 import com.baro.common.utils.ImageExtensionConverter;
@@ -39,7 +40,7 @@ public class AwsImageUploader implements ImageUploader {
             s3Client.putObject(putObjectRequest, requestBody);
             return new ImageUploadResult(urlSafetyKey);
         } catch (IOException ioException) {
-            throw new RuntimeException(ioException); //TODO: custom exception 으로 수정
+            throw new ImageUploadException("Error on converting or uploading image", ioException);
         }
     }
 

--- a/src/main/java/com/baro/common/infra/aws/s3/AwsImageUploader.java
+++ b/src/main/java/com/baro/common/infra/aws/s3/AwsImageUploader.java
@@ -23,7 +23,7 @@ public class AwsImageUploader implements ImageUploader {
         try {
             String urlSafetyKey = changeToUrlSafetyKey(file);
             PutObjectRequest putObjectRequest = PutObjectRequest.builder()
-                    .bucket(awsS3Property.bucketName())
+                    .bucket(awsS3Property.bucket())
                     .key(awsS3Property.key() + urlSafetyKey)
                     .contentType(file.getContentType())
                     .contentDisposition("inline")

--- a/src/main/java/com/baro/common/infra/aws/s3/AwsImageUploader.java
+++ b/src/main/java/com/baro/common/infra/aws/s3/AwsImageUploader.java
@@ -22,21 +22,20 @@ public class AwsImageUploader implements ImageUploader {
 
     @Override
     public void upload(MultipartFile file) {
-        try {
-            String urlSafetyKey = changeToUrlSafetyKey(file);
-            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
-                    .bucket(awsS3Property.bucket())
-                    .key(awsS3Property.key() + urlSafetyKey)
-                    .contentType(file.getContentType())
-                    .contentDisposition("inline")
-                    .build();
+        String urlSafetyKey = changeToUrlSafetyKey(file);
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(awsS3Property.bucket())
+                .key(awsS3Property.key() + urlSafetyKey)
+                .contentType(file.getContentType())
+                .contentDisposition("inline")
+                .build();
 
+        try {
             byte[] jpegImageBytes = ImageExtensionConverter.toJpeg(file);
             ByteArrayInputStream inputStream = new ByteArrayInputStream(jpegImageBytes);
             RequestBody requestBody = RequestBody.fromInputStream(inputStream, jpegImageBytes.length);
-
-            s3Client.putObject(putObjectRequest, requestBody);
             inputStream.close();
+            s3Client.putObject(putObjectRequest, requestBody);
         } catch (IOException ioException) {
             throw new RuntimeException(ioException); //TODO: custom exception 으로 수정
         }

--- a/src/main/java/com/baro/common/infra/aws/s3/AwsImageUploader.java
+++ b/src/main/java/com/baro/common/infra/aws/s3/AwsImageUploader.java
@@ -1,12 +1,44 @@
 package com.baro.common.infra.aws.s3;
 
 import com.baro.common.client.ImageUploader;
+import java.io.IOException;
+import java.util.Objects;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
+@RequiredArgsConstructor
+@Component
 public class AwsImageUploader implements ImageUploader {
 
+    private final S3Client s3Client;
+    private final AwsS3Property awsS3Property;
+
     @Override
-    public void upload(final MultipartFile file) {
-        
+    public void upload(MultipartFile file) {
+        try {
+            String urlSafetyKey = changeToUrlSafetyKey(file);
+            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                    .bucket(awsS3Property.bucketName())
+                    .key(awsS3Property.key() + urlSafetyKey)
+                    .contentType(file.getContentType())
+                    .contentDisposition("inline")
+                    .build();
+
+            RequestBody requestBody = RequestBody.fromInputStream(file.getInputStream(), file.getSize());
+            s3Client.putObject(putObjectRequest, requestBody);
+        } catch (IOException ioException) {
+            throw new RuntimeException(ioException); //TODO: custom exception 으로 수정
+        }
+    }
+
+    private String changeToUrlSafetyKey(MultipartFile file) {
+        String originalFilename = file.getOriginalFilename();
+        String replacedFileName = Objects.requireNonNull(originalFilename).replace(" ", "_");
+        return replacedFileName + "-" + UUID.randomUUID();
     }
 }

--- a/src/main/java/com/baro/common/infra/aws/s3/AwsImageUploader.java
+++ b/src/main/java/com/baro/common/infra/aws/s3/AwsImageUploader.java
@@ -1,0 +1,12 @@
+package com.baro.common.infra.aws.s3;
+
+import com.baro.common.client.ImageUploader;
+import org.springframework.web.multipart.MultipartFile;
+
+public class AwsImageUploader implements ImageUploader {
+
+    @Override
+    public void upload(final MultipartFile file) {
+        
+    }
+}

--- a/src/main/java/com/baro/common/infra/aws/s3/AwsImageUploader.java
+++ b/src/main/java/com/baro/common/infra/aws/s3/AwsImageUploader.java
@@ -1,6 +1,7 @@
 package com.baro.common.infra.aws.s3;
 
-import com.baro.common.client.ImageUploader;
+import com.baro.common.image.ImageUploader;
+import com.baro.common.image.dto.ImageUploadResult;
 import com.baro.common.utils.ImageExtensionConverter;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -21,7 +22,7 @@ public class AwsImageUploader implements ImageUploader {
     private final AwsS3Property awsS3Property;
 
     @Override
-    public void upload(MultipartFile file) {
+    public ImageUploadResult upload(MultipartFile file) {
         String urlSafetyKey = changeToUrlSafetyKey(file);
         PutObjectRequest putObjectRequest = PutObjectRequest.builder()
                 .bucket(awsS3Property.bucket())
@@ -36,6 +37,7 @@ public class AwsImageUploader implements ImageUploader {
             RequestBody requestBody = RequestBody.fromInputStream(inputStream, jpegImageBytes.length);
             inputStream.close();
             s3Client.putObject(putObjectRequest, requestBody);
+            return new ImageUploadResult(urlSafetyKey);
         } catch (IOException ioException) {
             throw new RuntimeException(ioException); //TODO: custom exception 으로 수정
         }

--- a/src/main/java/com/baro/common/infra/aws/s3/AwsS3Config.java
+++ b/src/main/java/com/baro/common/infra/aws/s3/AwsS3Config.java
@@ -1,0 +1,26 @@
+package com.baro.common.infra.aws.s3;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@RequiredArgsConstructor
+@Configuration
+public class AwsS3Config {
+
+    private final AwsS3Property awsS3Property;
+
+    @Bean
+    public S3Client amazonS3Client() {
+        AwsBasicCredentials credentials =
+                AwsBasicCredentials.create(awsS3Property.accessKey(), awsS3Property.secretKey());
+        return S3Client.builder()
+                .credentialsProvider(StaticCredentialsProvider.create(credentials))
+                .region(Region.AP_NORTHEAST_2)
+                .build();
+    }
+}

--- a/src/main/java/com/baro/common/infra/aws/s3/AwsS3Property.java
+++ b/src/main/java/com/baro/common/infra/aws/s3/AwsS3Property.java
@@ -1,0 +1,12 @@
+package com.baro.common.infra.aws.s3;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "aws.s3")
+public record AwsS3Property(
+        String bucketName,
+        String key,
+        String accessKey,
+        String secretKey
+) {
+}

--- a/src/main/java/com/baro/common/infra/aws/s3/AwsS3Property.java
+++ b/src/main/java/com/baro/common/infra/aws/s3/AwsS3Property.java
@@ -4,7 +4,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "aws.s3")
 public record AwsS3Property(
-        String bucketName,
+        String bucket,
         String key,
         String accessKey,
         String secretKey

--- a/src/main/java/com/baro/common/utils/ImageExtensionConverter.java
+++ b/src/main/java/com/baro/common/utils/ImageExtensionConverter.java
@@ -1,0 +1,29 @@
+package com.baro.common.utils;
+
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import javax.imageio.ImageIO;
+import org.springframework.web.multipart.MultipartFile;
+
+public class ImageExtensionConverter {
+
+    public static byte[] toJpeg(MultipartFile image) throws IOException {
+        BufferedImage originalImage = ImageIO.read(image.getInputStream());
+        BufferedImage jpegImage = new BufferedImage(
+                originalImage.getWidth(),
+                originalImage.getHeight(),
+                BufferedImage.TYPE_INT_RGB);
+
+        Graphics2D graphics = jpegImage.createGraphics();
+        graphics.drawImage(originalImage, 0, 0, null);
+        graphics.dispose();
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ImageIO.write(jpegImage, "jpeg", baos);
+        baos.close();
+
+        return baos.toByteArray();
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -18,3 +18,10 @@ spring:
 
     hibernate:
       ddl-auto: create
+
+aws:
+  s3:
+    access_key: test-key
+    secret_key: test-secret-key
+    bucket: "bucket"
+    key: "test/directory/"


### PR DESCRIPTION
## 관련된 이슈
BAR-135

## 작업 사항
- 이미지 저장을 위한 S3 버킷을 추가헀습니다.
- endpoint에 https, domain을 추가하기 위해 CDN을 구성하였습니다. `https://image.ba-ro.co.kr/${s3-object-key}`
- S3 이미지 업로드를 위해 access, secret key를 구성하였습니다. 
ncp에서도 동작 할 수 있게 `StaticCredentialsProvider`로 인증하였습니다.
- 업로드 요청 이미지에 대한 파일 변환 (png -> jpeg) 로직을 작성하였습니다.

## 기타
image 이름에 대해서 이미지 이름이 겹칠까봐 uuid 값을 추가하였는데요.
업로드 단계에서 해당 image의 url이 결정되다 보니 이 값을 db에 저장할 때 알 수 있도록 구성해야 했었는데요.
그래서 upload 이후 생성된 이미지 이름에 대한 정보를 담은 dto를 반환하도록 하였습니다.
아마 아래 예시처럼 사용될 것 같습니다!

>```java
>// ImageUploader.upload();
>public UploadImageResult upload(MultipartFile file) {
>    String uniqueFileName = generateUniqueName(file.getOriginalFileName());
>    // ...
>    
>    return new UploadImageResult(uniqueFileName)
>}
>
>
>// Client
>public void saveImage(MultipartFile file) {
>    UploadImageResult result = imageUploader.upload(file);
>    XxxRepository.updateProfileImage(result.getImageUrl());
>}
>```


