### PR TITLE
infra: redis 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'io.netty:netty-resolver-dns-native-macos:4.1.68.Final:osx-aarch_64'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-mysql'

--- a/src/main/java/com/baro/common/config/RedisConfig.java
+++ b/src/main/java/com/baro/common/config/RedisConfig.java
@@ -20,8 +20,8 @@ class RedisConfig {
     }
 
     @Bean
-    public RedisTemplate<?, ?> redisTemplate() {
-        RedisTemplate<byte[], byte[]> template = new RedisTemplate<>();
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
 
         template.setKeySerializer(new StringRedisSerializer());
         template.setValueSerializer(new StringRedisSerializer());

--- a/src/main/java/com/baro/common/config/RedisConfig.java
+++ b/src/main/java/com/baro/common/config/RedisConfig.java
@@ -1,0 +1,33 @@
+package com.baro.common.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@RequiredArgsConstructor
+class RedisConfig {
+
+    private final RedisProperty redisProperty;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisProperty.host(), redisProperty.port());
+    }
+
+    @Bean
+    public RedisTemplate<?, ?> redisTemplate() {
+        RedisTemplate<byte[], byte[]> template = new RedisTemplate<>();
+
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+        template.setConnectionFactory(redisConnectionFactory());
+
+        template.afterPropertiesSet();
+        return template;
+    }
+}

--- a/src/main/java/com/baro/common/config/RedisProperty.java
+++ b/src/main/java/com/baro/common/config/RedisProperty.java
@@ -1,0 +1,10 @@
+package com.baro.common.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "spring.data.redis")
+public record RedisProperty(
+        String host,
+        Integer port
+) {
+}

--- a/src/test/java/com/baro/common/config/RedisPropertyTest.java
+++ b/src/test/java/com/baro/common/config/RedisPropertyTest.java
@@ -1,0 +1,21 @@
+package com.baro.common.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SuppressWarnings("NonAsciiCharacters")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+class RedisPropertyTest {
+
+    @Autowired
+    private RedisProperty property;
+
+    @Test
+    void Redis_프로퍼티값_바인딩_테스트() {
+        assertNotNull(property.host());
+        assertNotNull(property.port());
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -18,3 +18,8 @@ spring:
 
     hibernate:
       ddl-auto: create
+
+  data:
+    redis:
+      host: localhost
+      port: 6379


### PR DESCRIPTION
## 관련된 이슈
<!-- 관련있는 이슈 번호(#000) 기입
merge를 기대하는 경우, close와 함께 기입-->
BAR-137

## 작업 사항
##### 서버 인스턴스에서 redis 접속방법
- aws : `redis-cli -h "elasticache 엔드포인트주소"`
- ncp : `redis-cli -h "cloud db for redis DNS주소"`
##### submodule 업데이트
- prod, dev, local환경에 맞는 redis host,port를 설정하였습니다.
##### redis config추가
- redis property, redis config를 추가하였습니다.
- 기본적으로 String자료구조만 설정해놨습니다!


## 기타
- gcc, make, pkg-config 설치해놨습니당
