### PR TITLE
feat: 카카오 로그인 이메일 정보 추가

### DIFF
--- a/src/main/java/com/baro/auth/application/oauth/dto/OAuthMemberInfo.java
+++ b/src/main/java/com/baro/auth/application/oauth/dto/OAuthMemberInfo.java
@@ -4,6 +4,5 @@ public record OAuthMemberInfo(
         String oAuthId,
         String name,
         String email
-        // TODO: User 설계에 따라 필드 추가
 ) {
 }

--- a/src/main/java/com/baro/auth/infra/oauth/google/config/GoogleOAuthProperty.java
+++ b/src/main/java/com/baro/auth/infra/oauth/google/config/GoogleOAuthProperty.java
@@ -8,7 +8,6 @@ public record GoogleOAuthProperty(
         String clientSecret,
         String signInAuthorizeUrl,
         String responseType,
-        String tokenUri,
         String redirectUri,
         String[] scope
 ) {

--- a/src/main/java/com/baro/auth/infra/oauth/kakao/dto/KakaoMemberResponse.java
+++ b/src/main/java/com/baro/auth/infra/oauth/kakao/dto/KakaoMemberResponse.java
@@ -25,12 +25,12 @@ public record KakaoMemberResponse(
     ) {
     }
 
-    record KakaoAccount(
+    public record KakaoAccount(
             Boolean profileNicknameNeedsAgreement,
             Profile profile,
             String email
     ) {
-        record Profile(
+        public record Profile(
                 String nickname
         ) {
         }

--- a/src/main/java/com/baro/auth/infra/oauth/kakao/dto/KakaoMemberResponse.java
+++ b/src/main/java/com/baro/auth/infra/oauth/kakao/dto/KakaoMemberResponse.java
@@ -16,7 +16,7 @@ public record KakaoMemberResponse(
         return new OAuthMemberInfo(
                 String.valueOf(id),
                 properties.nickname,
-                "email" //TODO: 비즈앱 전환후 email 추가
+                kakaoAccount.email
         );
     }
 
@@ -27,7 +27,8 @@ public record KakaoMemberResponse(
 
     record KakaoAccount(
             Boolean profileNicknameNeedsAgreement,
-            Profile profile
+            Profile profile,
+            String email
     ) {
         record Profile(
                 String nickname

--- a/src/main/java/com/baro/auth/infra/oauth/naver/NaverOAuthClient.java
+++ b/src/main/java/com/baro/auth/infra/oauth/naver/NaverOAuthClient.java
@@ -1,18 +1,17 @@
 package com.baro.auth.infra.oauth.naver;
 
-import com.baro.auth.infra.oauth.naver.config.NaverOAuthProperty;
-import com.baro.auth.infra.oauth.naver.dto.NaverMemberResponse;
-import com.baro.auth.infra.oauth.naver.dto.NaverTokenResponse;
 import com.baro.auth.application.oauth.OAuthClient;
 import com.baro.auth.application.oauth.dto.OAuthMemberInfo;
 import com.baro.auth.application.oauth.dto.OAuthTokenInfo;
 import com.baro.auth.domain.oauth.OAuthServiceType;
+import com.baro.auth.infra.oauth.naver.config.NaverOAuthProperty;
+import com.baro.auth.infra.oauth.naver.dto.NaverMemberResponse;
+import com.baro.auth.infra.oauth.naver.dto.NaverTokenResponse;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponentsBuilder;
-
-import java.util.LinkedHashMap;
-import java.util.Map;
 
 @RequiredArgsConstructor
 @Component
@@ -27,7 +26,7 @@ public class NaverOAuthClient implements OAuthClient {
                 .fromUriString(naverOAuthProperty.signInAuthorizeUrl())
                 .queryParam("response_type", naverOAuthProperty.responseType())
                 .queryParam("client_id", naverOAuthProperty.clientId())
-                .queryParam("redirect_uri", naverOAuthProperty.redirectUrl())
+                .queryParam("redirect_uri", naverOAuthProperty.redirectUri())
                 .queryParam("state", naverOAuthProperty.state())
                 .toUriString();
     }
@@ -51,7 +50,8 @@ public class NaverOAuthClient implements OAuthClient {
 
     @Override
     public OAuthMemberInfo requestMemberInfo(OAuthTokenInfo oAuthTokenInfo) {
-        NaverMemberResponse naverMemberResponse = naverRequestApi.requestMemberInfo("Bearer " + oAuthTokenInfo.accessToken());
+        NaverMemberResponse naverMemberResponse = naverRequestApi.requestMemberInfo(
+                "Bearer " + oAuthTokenInfo.accessToken());
         return naverMemberResponse.toOAuthMemberInfo();
     }
 }

--- a/src/main/java/com/baro/auth/infra/oauth/naver/config/NaverOAuthProperty.java
+++ b/src/main/java/com/baro/auth/infra/oauth/naver/config/NaverOAuthProperty.java
@@ -8,7 +8,7 @@ public record NaverOAuthProperty(
         String clientSecret,
         String signInAuthorizeUrl,
         String responseType,
-        String redirectUrl,
+        String redirectUri,
         String state,
         String grantType
 ) {

--- a/src/test/java/com/baro/auth/application/oauth/AuthServiceTest.java
+++ b/src/test/java/com/baro/auth/application/oauth/AuthServiceTest.java
@@ -7,15 +7,13 @@ import com.baro.auth.application.AuthService;
 import com.baro.auth.application.TokenTranslator;
 import com.baro.auth.application.dto.SignInDto;
 import com.baro.auth.domain.Token;
-import com.baro.member.fake.FakeNicknameCreator;
 import com.baro.auth.fake.jwt.FakeTokenTranslator;
 import com.baro.member.application.MemberCreator;
 import com.baro.member.domain.Member;
 import com.baro.member.domain.MemberRepository;
 import com.baro.member.fake.FakeMemberRepository;
-
+import com.baro.member.fake.FakeNicknameCreator;
 import java.util.List;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
@@ -27,13 +25,13 @@ class AuthServiceTest {
 
     private AuthService authService;
     private MemberRepository memberRepository;
-    private MemberCreator memberCreator;
 
     @BeforeEach
     void setUpOAuthClientRequest() {
         memberRepository = new FakeMemberRepository();
         TokenTranslator tokenTranslator = new FakeTokenTranslator();
-        memberCreator = new MemberCreator(memberRepository, new FakeNicknameCreator(List.of("nickname1", "nickname2")));
+        FakeNicknameCreator fakeNicknameCreator = new FakeNicknameCreator(List.of("nickname1", "nickname2"));
+        MemberCreator memberCreator = new MemberCreator(memberRepository, fakeNicknameCreator);
         authService = new AuthService(memberRepository, memberCreator, tokenTranslator);
     }
 

--- a/src/test/java/com/baro/auth/application/oauth/OAuthInfoProviderTest.java
+++ b/src/test/java/com/baro/auth/application/oauth/OAuthInfoProviderTest.java
@@ -8,22 +8,22 @@ import com.baro.auth.domain.oauth.OAuthServiceType;
 import com.baro.auth.fake.oauth.FakeGoogleOAuthClient;
 import com.baro.auth.fake.oauth.FakeKakaoOAuthClient;
 import com.baro.auth.fake.oauth.FakeNaverOAuthClient;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import java.util.Set;
 
 @SuppressWarnings("NonAsciiCharacters")
 class OAuthInfoProviderTest {
 
     private OAuthInfoProvider oAuthInfoProvider;
-    OAuthClient fakeKakaoOAuthClient = new FakeKakaoOAuthClient();
-    OAuthClient fakeNaverOAuthClient = new FakeNaverOAuthClient();
-    OAuthClient fakeGoogleOAuthClient = new FakeGoogleOAuthClient();
+    final OAuthClient fakeKakaoOAuthClient = new FakeKakaoOAuthClient();
+    final OAuthClient fakeNaverOAuthClient = new FakeNaverOAuthClient();
+    final OAuthClient fakeGoogleOAuthClient = new FakeGoogleOAuthClient();
 
     @BeforeEach
     void setUp() {
-        oAuthInfoProvider = new OAuthInfoProvider(Set.of(fakeKakaoOAuthClient, fakeNaverOAuthClient, fakeGoogleOAuthClient));
+        oAuthInfoProvider =
+                new OAuthInfoProvider(Set.of(fakeKakaoOAuthClient, fakeNaverOAuthClient, fakeGoogleOAuthClient));
     }
 
     @Test

--- a/src/test/java/com/baro/auth/domain/AuthMemberTest.java
+++ b/src/test/java/com/baro/auth/domain/AuthMemberTest.java
@@ -1,15 +1,16 @@
 package com.baro.auth.domain;
 
-import org.junit.jupiter.api.Test;
-
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("NonAsciiCharacters")
 class AuthMemberTest {
 
     @Test
     void AuthMember_동일성_테스트() {
-        assertThat(new AuthMember(1000L)).isEqualTo(new AuthMember(1000L));
+        AuthMember actual = new AuthMember(1000L);
+        AuthMember expected = new AuthMember(1000L);
+        assertThat(actual).isEqualTo(expected);
     }
 }

--- a/src/test/java/com/baro/auth/domain/TokenTest.java
+++ b/src/test/java/com/baro/auth/domain/TokenTest.java
@@ -1,15 +1,16 @@
 package com.baro.auth.domain;
 
-import org.junit.jupiter.api.Test;
-
 import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("NonAsciiCharacters")
 class TokenTest {
 
     @Test
     void token_동일성_테스트() {
-        assertThat(new Token("accessToken", "refreshToken"))
-                .isEqualTo(new Token("accessToken", "refreshToken"));
+        Token actual = new Token("accessToken", "refreshToken");
+        Token expected = new Token("accessToken", "refreshToken");
+        assertThat(actual).isEqualTo(expected);
     }
 }

--- a/src/test/java/com/baro/auth/fake/jwt/FakeTokenCreator.java
+++ b/src/test/java/com/baro/auth/fake/jwt/FakeTokenCreator.java
@@ -1,14 +1,13 @@
 package com.baro.auth.fake.jwt;
 
-import com.baro.auth.domain.Token;
 import com.baro.auth.application.TokenCreator;
-
+import com.baro.auth.domain.Token;
 import java.time.Instant;
 
 public class FakeTokenCreator implements TokenCreator {
 
-    private String accessToken;
-    private String refreshToken;
+    private final String accessToken;
+    private final String refreshToken;
 
     public FakeTokenCreator(String accessToken, String refreshToken) {
         this.accessToken = accessToken;

--- a/src/test/java/com/baro/auth/fake/jwt/FakeTokenDecrypter.java
+++ b/src/test/java/com/baro/auth/fake/jwt/FakeTokenDecrypter.java
@@ -4,7 +4,7 @@ import com.baro.auth.application.TokenDecrypter;
 
 public class FakeTokenDecrypter implements TokenDecrypter {
 
-    private Long decryptedResult;
+    private final Long decryptedResult;
 
     public FakeTokenDecrypter(Long decryptedResult) {
         this.decryptedResult = decryptedResult;

--- a/src/test/java/com/baro/auth/infra/jwt/JwtPropertyTest.java
+++ b/src/test/java/com/baro/auth/infra/jwt/JwtPropertyTest.java
@@ -1,10 +1,11 @@
 package com.baro.auth.infra.jwt;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Objects;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 @SuppressWarnings("NonAsciiCharacters")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
@@ -15,10 +16,9 @@ class JwtPropertyTest {
 
     @Test
     void Jwt_프로퍼티_값_바인딩_테스트() {
-        assertNotNull(jwtProperty.bearerType());
-        assertNotNull(jwtProperty.accessSecretKey());
-        assertNotNull(jwtProperty.refreshSecretKey());
-        assertNotNull(jwtProperty.accessTokenExpireTime());
-        assertNotNull(jwtProperty.refreshTokenExpireTime());
+        // when & then
+        assertThat(jwtProperty)
+                .usingRecursiveAssertion()
+                .allFieldsSatisfy(Objects::nonNull);
     }
 }

--- a/src/test/java/com/baro/auth/infra/oauth/google/config/GoogleOAuthPropertyTest.java
+++ b/src/test/java/com/baro/auth/infra/oauth/google/config/GoogleOAuthPropertyTest.java
@@ -1,12 +1,12 @@
 package com.baro.auth.infra.oauth.google.config;
 
-import com.baro.auth.infra.oauth.google.config.GoogleOAuthProperty;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Objects;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @SuppressWarnings("NonAsciiCharacters")
 @SpringBootTest(webEnvironment = WebEnvironment.NONE)
@@ -17,6 +17,8 @@ class GoogleOAuthPropertyTest {
 
     @Test
     void Google_프로퍼티_값_바인딩_테스트() {
-        assertNotNull(googleOAuthProperty.clientId());
+        assertThat(googleOAuthProperty)
+                .usingRecursiveAssertion()
+                .allFieldsSatisfy(Objects::nonNull);
     }
 }

--- a/src/test/java/com/baro/auth/infra/oauth/kakao/config/KakaoOAuthPropertyTest.java
+++ b/src/test/java/com/baro/auth/infra/oauth/kakao/config/KakaoOAuthPropertyTest.java
@@ -2,6 +2,7 @@ package com.baro.auth.infra.oauth.kakao.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Objects;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -16,10 +17,9 @@ class KakaoOAuthPropertyTest {
 
     @Test
     void Kakao_프로퍼티_값_바인딩_테스트() {
-        // when
-        String[] userInfoRequestScopes = kakaoOAuthProperty.scope();
-
-        // then
-        assertThat(userInfoRequestScopes).contains("account_email");
+        // when & then
+        assertThat(kakaoOAuthProperty)
+                .usingRecursiveAssertion()
+                .allFieldsSatisfy(Objects::nonNull);
     }
 }

--- a/src/test/java/com/baro/auth/infra/oauth/kakao/config/KakaoOAuthPropertyTest.java
+++ b/src/test/java/com/baro/auth/infra/oauth/kakao/config/KakaoOAuthPropertyTest.java
@@ -2,7 +2,6 @@ package com.baro.auth.infra.oauth.kakao.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.baro.auth.infra.oauth.kakao.config.KakaoOAuthProperty;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -17,6 +16,10 @@ class KakaoOAuthPropertyTest {
 
     @Test
     void Kakao_프로퍼티_값_바인딩_테스트() {
-        assertThat(kakaoOAuthProperty.clientId()).isNotNull();
+        // when
+        String[] userInfoRequestScopes = kakaoOAuthProperty.scope();
+
+        // then
+        assertThat(userInfoRequestScopes).contains("account_email");
     }
 }

--- a/src/test/java/com/baro/auth/infra/oauth/naver/config/NaverOAuthPropertyTest.java
+++ b/src/test/java/com/baro/auth/infra/oauth/naver/config/NaverOAuthPropertyTest.java
@@ -1,21 +1,24 @@
 package com.baro.auth.infra.oauth.naver.config;
 
-import com.baro.auth.infra.oauth.naver.config.NaverOAuthProperty;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Objects;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 
 @SuppressWarnings("NonAsciiCharacters")
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@SpringBootTest(webEnvironment = WebEnvironment.NONE)
 class NaverOAuthPropertyTest {
 
     @Autowired
-    private NaverOAuthProperty property;
+    private NaverOAuthProperty naverOAuthProperty;
 
     @Test
     void Naver_프로퍼티값_바인딩_테스트() {
-        assertNotNull(property.clientId());
+        assertThat(naverOAuthProperty)
+                .usingRecursiveAssertion()
+                .allFieldsSatisfy(Objects::nonNull);
     }
 }

--- a/src/test/java/com/baro/auth/presentation/AuthenticationArgumentResolverTest.java
+++ b/src/test/java/com/baro/auth/presentation/AuthenticationArgumentResolverTest.java
@@ -1,5 +1,8 @@
 package com.baro.auth.presentation;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
 import com.baro.auth.application.TokenTranslator;
 import com.baro.auth.domain.AuthMember;
 import io.restassured.RestAssured;
@@ -8,6 +11,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
@@ -16,11 +20,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
-
 @SuppressWarnings("NonAsciiCharacters")
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 class AuthenticationArgumentResolverTest {
 
     @MockBean

--- a/src/test/java/com/baro/auth/presentation/oauth/OAuthApiDocumentTest.java
+++ b/src/test/java/com/baro/auth/presentation/oauth/OAuthApiDocumentTest.java
@@ -3,25 +3,27 @@ package com.baro.auth.presentation.oauth;
 import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.document;
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.anyMap;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
-import static org.springframework.restdocs.request.RequestDocumentation.*;
-
-import com.baro.common.RestApiDocumentationTest;
-
-import java.nio.charset.StandardCharsets;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 
 import com.baro.auth.infra.oauth.kakao.KakaoOAuthClient;
 import com.baro.auth.infra.oauth.kakao.KakaoRequestApi;
 import com.baro.auth.infra.oauth.kakao.dto.KakaoMemberResponse;
+import com.baro.auth.infra.oauth.kakao.dto.KakaoMemberResponse.KakaoAccount;
 import com.baro.auth.infra.oauth.kakao.dto.KakaoTokenResponse;
+import com.baro.common.RestApiDocumentationTest;
+import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
-
-import static org.mockito.Mockito.*;
 
 class OAuthApiDocumentTest extends RestApiDocumentationTest {
 
@@ -66,7 +68,9 @@ class OAuthApiDocumentTest extends RestApiDocumentationTest {
                         1000, "refreshToken", 1000, "scope"));
         when(kakaoRequestApi.requestMemberInfo(anyString()))
                 .thenReturn(new KakaoMemberResponse(1L, "nickname",
-                        new KakaoMemberResponse.Properties("nickname"), null));
+                        new KakaoMemberResponse.Properties("nickname"),
+                        new KakaoAccount(false, new KakaoAccount.Profile("nickname"), "email")
+                ));
 
         // when
         var response = given(requestSpec).log().all()

--- a/src/test/java/com/baro/common/config/RedisPropertyTest.java
+++ b/src/test/java/com/baro/common/config/RedisPropertyTest.java
@@ -1,21 +1,24 @@
 package com.baro.common.config;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Objects;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-
-import static org.junit.jupiter.api.Assertions.*;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 
 @SuppressWarnings("NonAsciiCharacters")
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@SpringBootTest(webEnvironment = WebEnvironment.NONE)
 class RedisPropertyTest {
 
     @Autowired
-    private RedisProperty property;
+    private RedisProperty redisProperty;
 
     @Test
     void Redis_프로퍼티값_바인딩_테스트() {
-        assertNotNull(property.host());
-        assertNotNull(property.port());
+        assertThat(redisProperty)
+                .usingRecursiveAssertion()
+                .allFieldsSatisfy(Objects::nonNull);
     }
 }


### PR DESCRIPTION
## 관련된 이슈
- BAR-181

## 작업 사항
- Kakao application Biz 앱 전환하였습니다.
- 로그인 후, 사용자의 이메일 정보를 저장하도록 추가하였습니다.
