### PR TITLE
refactor: 테스트 코드 컨벤션 리팩토링

### DIFF
--- a/src/main/java/com/baro/auth/infra/jwt/JwtTokenDecrypter.java
+++ b/src/main/java/com/baro/auth/infra/jwt/JwtTokenDecrypter.java
@@ -7,10 +7,9 @@ import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
+import javax.crypto.SecretKey;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-
-import javax.crypto.SecretKey;
 
 @RequiredArgsConstructor
 @Component
@@ -20,6 +19,7 @@ class JwtTokenDecrypter implements TokenDecrypter {
 
     @Override
     public Long decryptAccessToken(String authorization) {
+        System.out.println("authorization = " + authorization);
         String token = validateTokenType(authorization);
         SecretKey accessTokenSecretKey = Keys.hmacShaKeyFor(jwtProperty.accessSecretKey().getBytes());
         try {
@@ -32,6 +32,7 @@ class JwtTokenDecrypter implements TokenDecrypter {
         } catch (ExpiredJwtException e) {
             throw new JwtTokenException(JwtTokenExceptionType.EXPIRED_JWT_TOKEN);
         } catch (JwtException e) {
+            System.out.println(e.getMessage());
             throw new JwtTokenException(JwtTokenExceptionType.INVALID_JWT_TOKEN);
         }
     }

--- a/src/main/java/com/baro/auth/infra/jwt/JwtTokenDecrypter.java
+++ b/src/main/java/com/baro/auth/infra/jwt/JwtTokenDecrypter.java
@@ -19,7 +19,6 @@ class JwtTokenDecrypter implements TokenDecrypter {
 
     @Override
     public Long decryptAccessToken(String authorization) {
-        System.out.println("authorization = " + authorization);
         String token = validateTokenType(authorization);
         SecretKey accessTokenSecretKey = Keys.hmacShaKeyFor(jwtProperty.accessSecretKey().getBytes());
         try {
@@ -32,7 +31,6 @@ class JwtTokenDecrypter implements TokenDecrypter {
         } catch (ExpiredJwtException e) {
             throw new JwtTokenException(JwtTokenExceptionType.EXPIRED_JWT_TOKEN);
         } catch (JwtException e) {
-            System.out.println(e.getMessage());
             throw new JwtTokenException(JwtTokenExceptionType.INVALID_JWT_TOKEN);
         }
     }

--- a/src/test/java/com/baro/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/baro/auth/application/AuthServiceTest.java
@@ -18,7 +18,6 @@ import com.baro.memofolder.domain.MemoFolder;
 import com.baro.memofolder.domain.MemoFolderRepository;
 import com.baro.memofolder.fake.FakeMemoFolderRepository;
 import java.util.List;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
@@ -43,7 +42,8 @@ class AuthServiceTest {
         memberCreator = new MemberCreator(memberRepository, fakeNicknameCreator);
         tokenStorage = new FakeTokenStorage(1000 * 60 * 60 * 24);
         memoFolderRepository = new FakeMemoFolderRepository();
-        authService = new AuthService(memberRepository, memberCreator, tokenTranslator, tokenStorage, memoFolderRepository);
+        authService = new AuthService(memberRepository, memberCreator, tokenTranslator, tokenStorage,
+                memoFolderRepository);
     }
 
     @Test

--- a/src/test/java/com/baro/auth/application/oauth/OAuthInfoProviderTest.java
+++ b/src/test/java/com/baro/auth/application/oauth/OAuthInfoProviderTest.java
@@ -10,8 +10,11 @@ import com.baro.auth.fake.oauth.FakeKakaoOAuthClient;
 import com.baro.auth.fake.oauth.FakeNaverOAuthClient;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
 
+@DisplayNameGeneration(ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
 class OAuthInfoProviderTest {
 

--- a/src/test/java/com/baro/auth/application/oauth/OAuthInfoProviderTest.java
+++ b/src/test/java/com/baro/auth/application/oauth/OAuthInfoProviderTest.java
@@ -18,10 +18,10 @@ import org.junit.jupiter.api.Test;
 @SuppressWarnings("NonAsciiCharacters")
 class OAuthInfoProviderTest {
 
-    private OAuthInfoProvider oAuthInfoProvider;
     final OAuthClient fakeKakaoOAuthClient = new FakeKakaoOAuthClient();
     final OAuthClient fakeNaverOAuthClient = new FakeNaverOAuthClient();
     final OAuthClient fakeGoogleOAuthClient = new FakeGoogleOAuthClient();
+    private OAuthInfoProvider oAuthInfoProvider;
 
     @BeforeEach
     void setUp() {

--- a/src/test/java/com/baro/auth/domain/AuthMemberTest.java
+++ b/src/test/java/com/baro/auth/domain/AuthMemberTest.java
@@ -2,8 +2,11 @@ package com.baro.auth.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
 
+@DisplayNameGeneration(ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
 class AuthMemberTest {
 

--- a/src/test/java/com/baro/auth/domain/TokenTest.java
+++ b/src/test/java/com/baro/auth/domain/TokenTest.java
@@ -2,8 +2,11 @@ package com.baro.auth.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
 
+@DisplayNameGeneration(ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
 class TokenTest {
 

--- a/src/test/java/com/baro/auth/domain/oauth/OAuthServiceTypeTest.java
+++ b/src/test/java/com/baro/auth/domain/oauth/OAuthServiceTypeTest.java
@@ -3,11 +3,13 @@ package com.baro.auth.domain.oauth;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.baro.auth.domain.oauth.OAuthServiceType;
 import com.baro.auth.exception.oauth.OAuthException;
 import com.baro.auth.exception.oauth.OAuthExceptionType;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
 
+@DisplayNameGeneration(ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
 class OAuthServiceTypeTest {
 

--- a/src/test/java/com/baro/auth/fake/jwt/FakeTokenStorage.java
+++ b/src/test/java/com/baro/auth/fake/jwt/FakeTokenStorage.java
@@ -7,7 +7,6 @@ import com.baro.auth.exception.jwt.JwtTokenException;
 import com.baro.auth.exception.jwt.JwtTokenExceptionType;
 import com.baro.common.time.TimeServer;
 import com.baro.common.time.fake.FakeTimeServer;
-
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Map;
@@ -17,7 +16,7 @@ public class FakeTokenStorage implements TokenStorage {
 
     private final Map<String, TokenInfo> tokens = new ConcurrentHashMap<>();
     private final long ttl;
-    private TimeServer timeServer = new FakeTimeServer(Instant.now());
+    private final TimeServer timeServer = new FakeTimeServer(Instant.now());
 
     public FakeTokenStorage(long ttl) {
         this.ttl = ttl;
@@ -33,7 +32,7 @@ public class FakeTokenStorage implements TokenStorage {
         if (!tokens.containsKey("RT:" + key)) {
             throw new AuthException(AuthExceptionType.REFRESH_TOKEN_DOES_NOT_EXIST);
         }
-        if (tokens.get("RT:" + key).expireTime().isAfter(timeServer.now())){
+        if (tokens.get("RT:" + key).expireTime().isAfter(timeServer.now())) {
             return tokens.get("RT:" + key).token();
         }
         throw new JwtTokenException(JwtTokenExceptionType.EXPIRED_JWT_TOKEN);

--- a/src/test/java/com/baro/auth/fixture/OAuthMemberInfoFixture.java
+++ b/src/test/java/com/baro/auth/fixture/OAuthMemberInfoFixture.java
@@ -1,0 +1,34 @@
+package com.baro.auth.fixture;
+
+import com.baro.auth.application.oauth.dto.OAuthMemberInfo;
+
+public class OAuthMemberInfoFixture {
+
+    public static OAuthMemberInfo 유빈() {
+        return new OAuthMemberInfo("1", "유빈", "email");
+    }
+
+    public static OAuthMemberInfo 태연() {
+        return new OAuthMemberInfo("2", "태연", "email");
+    }
+
+    public static OAuthMemberInfo 동균() {
+        return new OAuthMemberInfo("3", "동균", "email");
+    }
+
+    public static OAuthMemberInfo 원진() {
+        return new OAuthMemberInfo("4", "원진", "email");
+    }
+
+    public static OAuthMemberInfo 은지() {
+        return new OAuthMemberInfo("5", "은지", "email");
+    }
+
+    public static OAuthMemberInfo 준희() {
+        return new OAuthMemberInfo("6", "준희", "email");
+    }
+
+    public static OAuthMemberInfo 아현() {
+        return new OAuthMemberInfo("7", "아현", "email");
+    }
+}

--- a/src/test/java/com/baro/auth/infra/jwt/JwtPropertyTest.java
+++ b/src/test/java/com/baro/auth/infra/jwt/JwtPropertyTest.java
@@ -3,10 +3,13 @@ package com.baro.auth.infra.jwt;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Objects;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
+@DisplayNameGeneration(ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
 class JwtPropertyTest {

--- a/src/test/java/com/baro/auth/infra/jwt/JwtTokenDecrypterTest.java
+++ b/src/test/java/com/baro/auth/infra/jwt/JwtTokenDecrypterTest.java
@@ -1,5 +1,8 @@
 package com.baro.auth.infra.jwt;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
 import com.baro.auth.application.TokenCreator;
 import com.baro.auth.application.TokenDecrypter;
 import com.baro.auth.domain.Token;
@@ -7,15 +10,15 @@ import com.baro.auth.exception.jwt.JwtTokenException;
 import com.baro.auth.exception.jwt.JwtTokenExceptionType;
 import com.baro.common.time.TimeServer;
 import com.baro.common.time.fake.FakeTimeServer;
+import java.time.Instant;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import java.time.Instant;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
-
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
 class JwtTokenDecrypterTest {
 
     JwtProperty jwtProperty;

--- a/src/test/java/com/baro/auth/infra/jwt/JwtTokenTranslatorTest.java
+++ b/src/test/java/com/baro/auth/infra/jwt/JwtTokenTranslatorTest.java
@@ -1,5 +1,8 @@
 package com.baro.auth.infra.jwt;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
 import com.baro.auth.application.TokenCreator;
 import com.baro.auth.application.TokenDecrypter;
 import com.baro.auth.domain.Token;
@@ -7,13 +10,13 @@ import com.baro.auth.fake.jwt.FakeTokenCreator;
 import com.baro.auth.fake.jwt.FakeTokenDecrypter;
 import com.baro.common.time.TimeServer;
 import com.baro.common.time.fake.FakeTimeServer;
+import java.time.Instant;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
 
-import java.time.Instant;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
-
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
 class JwtTokenTranslatorTest {
 
     TimeServer timeServer = new FakeTimeServer(Instant.parse("2024-01-01T13:00:00.00Z"));

--- a/src/test/java/com/baro/auth/infra/oauth/google/config/GoogleOAuthPropertyTest.java
+++ b/src/test/java/com/baro/auth/infra/oauth/google/config/GoogleOAuthPropertyTest.java
@@ -3,11 +3,14 @@ package com.baro.auth.infra.oauth.google.config;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Objects;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 
+@DisplayNameGeneration(ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
 @SpringBootTest(webEnvironment = WebEnvironment.NONE)
 class GoogleOAuthPropertyTest {

--- a/src/test/java/com/baro/auth/infra/oauth/kakao/config/KakaoOAuthPropertyTest.java
+++ b/src/test/java/com/baro/auth/infra/oauth/kakao/config/KakaoOAuthPropertyTest.java
@@ -3,11 +3,14 @@ package com.baro.auth.infra.oauth.kakao.config;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Objects;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 
+@DisplayNameGeneration(ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
 @SpringBootTest(webEnvironment = WebEnvironment.NONE)
 class KakaoOAuthPropertyTest {

--- a/src/test/java/com/baro/auth/infra/oauth/naver/config/NaverOAuthPropertyTest.java
+++ b/src/test/java/com/baro/auth/infra/oauth/naver/config/NaverOAuthPropertyTest.java
@@ -3,11 +3,14 @@ package com.baro.auth.infra.oauth.naver.config;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Objects;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 
+@DisplayNameGeneration(ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
 @SpringBootTest(webEnvironment = WebEnvironment.NONE)
 class NaverOAuthPropertyTest {

--- a/src/test/java/com/baro/auth/presentation/AuthApiDocumentTest.java
+++ b/src/test/java/com/baro/auth/presentation/AuthApiDocumentTest.java
@@ -1,5 +1,16 @@
 package com.baro.auth.presentation;
 
+import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.document;
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+
 import com.baro.auth.application.AuthService;
 import com.baro.auth.application.TokenDecrypter;
 import com.baro.auth.application.dto.SignInDto;
@@ -7,21 +18,16 @@ import com.baro.auth.domain.Token;
 import com.baro.auth.exception.jwt.JwtTokenException;
 import com.baro.auth.exception.jwt.JwtTokenExceptionType;
 import com.baro.common.RestApiDocumentationTest;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 
-import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.document;
-import static io.restassured.RestAssured.given;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
-
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
 public class AuthApiDocumentTest extends RestApiDocumentationTest {
 
     @SpyBean

--- a/src/test/java/com/baro/auth/presentation/AuthApiTest.java
+++ b/src/test/java/com/baro/auth/presentation/AuthApiTest.java
@@ -1,5 +1,8 @@
 package com.baro.auth.presentation;
 
+import static com.baro.auth.fixture.OAuthMemberInfoFixture.동균;
+import static com.baro.auth.fixture.OAuthMemberInfoFixture.원진;
+import static com.baro.auth.fixture.OAuthMemberInfoFixture.은지;
 import static com.baro.common.acceptance.AcceptanceSteps.성공;
 import static com.baro.common.acceptance.AcceptanceSteps.응답값을_검증한다;
 import static com.baro.common.acceptance.AcceptanceSteps.잘못된_요청;
@@ -14,7 +17,6 @@ import com.baro.auth.application.TokenStorage;
 import com.baro.auth.domain.Token;
 import com.baro.auth.exception.jwt.JwtTokenException;
 import com.baro.auth.exception.jwt.JwtTokenExceptionType;
-import com.baro.auth.fixture.OAuthMemberInfoFixture;
 import com.baro.common.RestApiTest;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
@@ -33,7 +35,7 @@ public class AuthApiTest extends RestApiTest {
     @Test
     void reissue_성공() {
         // given
-        var 토큰 = 로그인(OAuthMemberInfoFixture.동균());
+        var 토큰 = 로그인(동균());
 
         // when
         var 응답 = 토큰_재발급_요청(토큰);
@@ -45,7 +47,7 @@ public class AuthApiTest extends RestApiTest {
     @Test
     void refresh토큰이_null일경우_예외발생() {
         // given
-        var 토큰 = 로그인(OAuthMemberInfoFixture.태연());
+        var 토큰 = 로그인(동균());
         var 리프레시_토큰이_없는_토큰 = new Token(토큰.accessToken(), null);
 
         // when
@@ -58,7 +60,7 @@ public class AuthApiTest extends RestApiTest {
     @Test
     void refresh토큰이_만료된_경우_예외발생() {
         // given
-        var 토큰 = 로그인(OAuthMemberInfoFixture.은지());
+        var 토큰 = 로그인(은지());
         리프레시_토큰_만료();
 
         // when
@@ -71,7 +73,7 @@ public class AuthApiTest extends RestApiTest {
     @Test
     void 저장된_refresh_token이_존재하지_않을_경우_예외발생() {
         // given
-        var 토큰 = 로그인(OAuthMemberInfoFixture.원진());
+        var 토큰 = 로그인(원진());
         리프레시_토큰이_서버에_존재하지_않는다();
 
         // when
@@ -84,7 +86,7 @@ public class AuthApiTest extends RestApiTest {
     @Test
     void 클라이언트와_토큰이_일치하지_않을_경우_예외발생() {
         // given
-        var 토큰 = 로그인(OAuthMemberInfoFixture.준희());
+        var 토큰 = 로그인(은지());
         var 뒤섞인_토큰 = new Token(토큰.accessToken(), 토큰.refreshToken() + "a");
 
         // when
@@ -97,7 +99,7 @@ public class AuthApiTest extends RestApiTest {
     @Test
     void 올바르지_않은_리프레시_토큰의_경우_예외발생() {
         // given
-        var 토큰 = 로그인(OAuthMemberInfoFixture.유빈());
+        var 토큰 = 로그인(원진());
         var 올바르지_않은_리프레시_토큰이_담긴_토큰 = new Token(토큰.accessToken(), "올바르지 않은 리프레시 토큰");
 
         // when
@@ -110,7 +112,7 @@ public class AuthApiTest extends RestApiTest {
     @Test
     void 리프레시_토큰이_Bearer_타입이_아닌경우_예외발생() {
         // given
-        var 토큰 = 로그인(OAuthMemberInfoFixture.태연());
+        var 토큰 = 로그인(은지());
 
         // when
         var 응답 = Bearer_타입이_아닌_토큰_재발급_요청(토큰);

--- a/src/test/java/com/baro/auth/presentation/AuthApiTest.java
+++ b/src/test/java/com/baro/auth/presentation/AuthApiTest.java
@@ -14,7 +14,7 @@ import com.baro.auth.application.AuthService;
 import com.baro.auth.application.TokenDecrypter;
 import com.baro.auth.application.dto.SignInDto;
 import com.baro.auth.domain.Token;
-import com.baro.common.RestApiDocumentationTest;
+import com.baro.common.RestApiTest;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
@@ -25,7 +25,7 @@ import org.springframework.http.HttpStatus;
 
 @DisplayNameGeneration(ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
-public class AuthApiDocumentTest extends RestApiDocumentationTest {
+public class AuthApiTest extends RestApiTest {
 
     @SpyBean
     TokenDecrypter tokenDecrypter;

--- a/src/test/java/com/baro/auth/presentation/AuthApiTest.java
+++ b/src/test/java/com/baro/auth/presentation/AuthApiTest.java
@@ -7,6 +7,7 @@ import static com.baro.common.acceptance.AcceptanceSteps.성공;
 import static com.baro.common.acceptance.AcceptanceSteps.응답값을_검증한다;
 import static com.baro.common.acceptance.AcceptanceSteps.잘못된_요청;
 import static com.baro.common.acceptance.auth.AuthAcceptanceSteps.Bearer_타입이_아닌_토큰_재발급_요청;
+import static com.baro.common.acceptance.auth.AuthAcceptanceSteps.잘못된_토큰_재발급_요청;
 import static com.baro.common.acceptance.auth.AuthAcceptanceSteps.토큰_재발급_요청;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
@@ -51,7 +52,7 @@ public class AuthApiTest extends RestApiTest {
         var 리프레시_토큰이_없는_토큰 = new Token(토큰.accessToken(), null);
 
         // when
-        var 응답 = 토큰_재발급_요청(리프레시_토큰이_없는_토큰);
+        var 응답 = 잘못된_토큰_재발급_요청(리프레시_토큰이_없는_토큰);
 
         // then
         응답값을_검증한다(응답, 잘못된_요청);
@@ -64,7 +65,7 @@ public class AuthApiTest extends RestApiTest {
         리프레시_토큰_만료();
 
         // when
-        var 응답 = 토큰_재발급_요청(토큰);
+        var 응답 = 잘못된_토큰_재발급_요청(토큰);
 
         // then
         응답값을_검증한다(응답, 잘못된_요청);
@@ -77,7 +78,7 @@ public class AuthApiTest extends RestApiTest {
         리프레시_토큰이_서버에_존재하지_않는다();
 
         // when
-        var 응답 = 토큰_재발급_요청(토큰);
+        var 응답 = 잘못된_토큰_재발급_요청(토큰);
 
         // then
         응답값을_검증한다(응답, 잘못된_요청);
@@ -90,7 +91,7 @@ public class AuthApiTest extends RestApiTest {
         var 뒤섞인_토큰 = new Token(토큰.accessToken(), 토큰.refreshToken() + "a");
 
         // when
-        var 응답 = 토큰_재발급_요청(뒤섞인_토큰);
+        var 응답 = 잘못된_토큰_재발급_요청(뒤섞인_토큰);
 
         // then
         응답값을_검증한다(응답, 잘못된_요청);
@@ -103,7 +104,7 @@ public class AuthApiTest extends RestApiTest {
         var 올바르지_않은_리프레시_토큰이_담긴_토큰 = new Token(토큰.accessToken(), "올바르지 않은 리프레시 토큰");
 
         // when
-        var 응답 = 토큰_재발급_요청(올바르지_않은_리프레시_토큰이_담긴_토큰);
+        var 응답 = 잘못된_토큰_재발급_요청(올바르지_않은_리프레시_토큰이_담긴_토큰);
 
         // then
         응답값을_검증한다(응답, 잘못된_요청);

--- a/src/test/java/com/baro/auth/presentation/AuthenticationArgumentResolverTest.java
+++ b/src/test/java/com/baro/auth/presentation/AuthenticationArgumentResolverTest.java
@@ -1,71 +1,46 @@
 package com.baro.auth.presentation;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
+import static com.baro.auth.presentation.ArgumentResolverAcceptanceSteps.Authorization_헤더를_포함한_요청;
+import static com.baro.common.acceptance.AcceptanceSteps.성공;
+import static com.baro.common.acceptance.AcceptanceSteps.응답값을_검증한다;
+import static com.baro.common.acceptance.AcceptanceSteps.응답의_특정_필드값을_검증한다;
+import static io.restassured.RestAssured.given;
 
-import com.baro.auth.application.TokenTranslator;
 import com.baro.auth.domain.AuthMember;
-import io.restassured.RestAssured;
+import com.baro.auth.domain.Token;
+import com.baro.auth.fixture.OAuthMemberInfoFixture;
+import com.baro.common.RestApiTest;
+import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.test.web.server.LocalServerPort;
-import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @DisplayNameGeneration(ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
-@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
-class AuthenticationArgumentResolverTest {
-
-    @MockBean
-    TokenTranslator tokenTranslator;
+class AuthenticationArgumentResolverTest extends RestApiTest {
 
     @Autowired
     AuthenticationArgumentResolver authenticationArgumentResolver;
 
-    @LocalServerPort
-    int port;
-
-    @BeforeEach
-    void setUp() {
-        RestAssured.port = port;
-    }
-
     @Test
     void 매개변수에_AuthMember가_존재하는경우_Argument_resolver를_거친다() {
         // given
-        String accessToken = "accessToken";
-        Long authMemberId = 1L;
-        setAccessTokenToReturn(authMemberId, accessToken);
+        var 토큰 = 로그인(OAuthMemberInfoFixture.아현());
 
         // when
-        Response response = RestAssured
-                .given()
-                .log().all()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .header("Authorization", accessToken)
-                .get("/test/auth");
+        var 응답 = Authorization_헤더를_포함한_요청(토큰);
 
         // then
-        String result = response.then().log().all()
-                .statusCode(HttpStatus.OK.value())
-                .extract().asString();
-        assertThat(result).isEqualTo(authMemberId.toString());
-    }
-
-    private void setAccessTokenToReturn(Long authMemberId, String accessToken) {
-        given(tokenTranslator.decodeAccessToken(accessToken)).willReturn(authMemberId);
+        응답값을_검증한다(응답, 성공);
+        응답의_특정_필드값을_검증한다(응답, "id", "1");
     }
 }
 
@@ -74,7 +49,24 @@ class AuthenticationArgumentResolverTest {
 class TestController {
 
     @GetMapping("/auth")
-    private Long authUserMethod(AuthMember authMember) {
-        return authMember.id();
+    private ResponseEntity<TestResponse> authUserMethod(AuthMember authMember) {
+        return ResponseEntity.ok().body(new TestResponse(authMember.id()));
+    }
+
+    record TestResponse(Long id) {
+    }
+}
+
+class ArgumentResolverAcceptanceSteps {
+
+    public static ExtractableResponse<Response> Authorization_헤더를_포함한_요청(Token 토큰) {
+        var url = "/test/auth";
+
+        return given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + 토큰.accessToken())
+                .when().get(url)
+                .then().log().all()
+                .extract();
     }
 }

--- a/src/test/java/com/baro/auth/presentation/AuthenticationArgumentResolverTest.java
+++ b/src/test/java/com/baro/auth/presentation/AuthenticationArgumentResolverTest.java
@@ -1,5 +1,6 @@
 package com.baro.auth.presentation;
 
+import static com.baro.auth.fixture.OAuthMemberInfoFixture.아현;
 import static com.baro.auth.presentation.ArgumentResolverAcceptanceSteps.Authorization_헤더를_포함한_요청;
 import static com.baro.common.acceptance.AcceptanceSteps.성공;
 import static com.baro.common.acceptance.AcceptanceSteps.응답값을_검증한다;
@@ -8,7 +9,6 @@ import static io.restassured.RestAssured.given;
 
 import com.baro.auth.domain.AuthMember;
 import com.baro.auth.domain.Token;
-import com.baro.auth.fixture.OAuthMemberInfoFixture;
 import com.baro.common.RestApiTest;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
@@ -33,7 +33,7 @@ class AuthenticationArgumentResolverTest extends RestApiTest {
     @Test
     void 매개변수에_AuthMember가_존재하는경우_Argument_resolver를_거친다() {
         // given
-        var 토큰 = 로그인(OAuthMemberInfoFixture.아현());
+        var 토큰 = 로그인(아현());
 
         // when
         var 응답 = Authorization_헤더를_포함한_요청(토큰);

--- a/src/test/java/com/baro/auth/presentation/AuthenticationArgumentResolverTest.java
+++ b/src/test/java/com/baro/auth/presentation/AuthenticationArgumentResolverTest.java
@@ -8,6 +8,8 @@ import com.baro.auth.domain.AuthMember;
 import io.restassured.RestAssured;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -20,6 +22,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@DisplayNameGeneration(ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 class AuthenticationArgumentResolverTest {

--- a/src/test/java/com/baro/auth/presentation/AuthenticationArgumentResolverTest.java
+++ b/src/test/java/com/baro/auth/presentation/AuthenticationArgumentResolverTest.java
@@ -1,7 +1,7 @@
 package com.baro.auth.presentation;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
+import static org.mockito.BDDMockito.given;
 
 import com.baro.auth.application.TokenTranslator;
 import com.baro.auth.domain.AuthMember;
@@ -44,9 +44,9 @@ class AuthenticationArgumentResolverTest {
     @Test
     void 매개변수에_AuthMember가_존재하는경우_Argument_resolver를_거친다() {
         // given
-        String testToken = "token";
+        String accessToken = "accessToken";
         Long authMemberId = 1L;
-        when(tokenTranslator.decodeAccessToken(testToken)).thenReturn(authMemberId);
+        setAccessTokenToReturn(authMemberId, accessToken);
 
         // when
         Response response = RestAssured
@@ -54,7 +54,7 @@ class AuthenticationArgumentResolverTest {
                 .log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when()
-                .header("Authorization", testToken)
+                .header("Authorization", accessToken)
                 .get("/test/auth");
 
         // then
@@ -62,6 +62,10 @@ class AuthenticationArgumentResolverTest {
                 .statusCode(HttpStatus.OK.value())
                 .extract().asString();
         assertThat(result).isEqualTo(authMemberId.toString());
+    }
+
+    private void setAccessTokenToReturn(Long authMemberId, String accessToken) {
+        given(tokenTranslator.decodeAccessToken(accessToken)).willReturn(authMemberId);
     }
 }
 

--- a/src/test/java/com/baro/auth/presentation/oauth/OAuthApiDocumentTest.java
+++ b/src/test/java/com/baro/auth/presentation/oauth/OAuthApiDocumentTest.java
@@ -20,12 +20,16 @@ import com.baro.auth.infra.oauth.kakao.dto.KakaoMemberResponse.KakaoAccount;
 import com.baro.auth.infra.oauth.kakao.dto.KakaoTokenResponse;
 import com.baro.common.RestApiDocumentationTest;
 import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
 class OAuthApiDocumentTest extends RestApiDocumentationTest {
 
     @MockBean

--- a/src/test/java/com/baro/auth/presentation/oauth/OAuthApiDocumentTest.java
+++ b/src/test/java/com/baro/auth/presentation/oauth/OAuthApiDocumentTest.java
@@ -3,9 +3,9 @@ package com.baro.auth.presentation.oauth;
 import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.document;
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.anyMap;
 import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
@@ -42,7 +42,7 @@ class OAuthApiDocumentTest extends RestApiDocumentationTest {
     AuthService authService;
 
     @Test
-    void oauth_sign_in_url() {
+    void OAuth_로그인시_필요한_url을_반환한다() {
         // given
         var url = "/auth/oauth/{oauthType}";
 
@@ -67,18 +67,12 @@ class OAuthApiDocumentTest extends RestApiDocumentationTest {
     }
 
     @Test
-    void oauth_sign_in() {
+    void OAuth로_로그인한다() {
         // given
         var url = "/auth/oauth/sign-in/{oauthType}";
 
-        when(kakaoRequestApi.requestToken(anyMap()))
-                .thenReturn(new KakaoTokenResponse("Bearer", "accessToken", "idToken",
-                        1000, "refreshToken", 1000, "scope"));
-        when(kakaoRequestApi.requestMemberInfo(anyString()))
-                .thenReturn(new KakaoMemberResponse(1L, "nickname",
-                        new KakaoMemberResponse.Properties("nickname"),
-                        new KakaoAccount(false, new KakaoAccount.Profile("nickname"), "email")
-                ));
+        setOAuthTokenRequest();
+        setOAuthMemberInfoRequest();
 
         // when
         var response = given(requestSpec).log().all()
@@ -97,5 +91,19 @@ class OAuthApiDocumentTest extends RestApiDocumentationTest {
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+
+    private void setOAuthTokenRequest() {
+        given(kakaoRequestApi.requestToken(anyMap()))
+                .willReturn(new KakaoTokenResponse("Bearer", "accessToken", "idToken",
+                        1000, "refreshToken", 1000, "scope"));
+    }
+
+    private void setOAuthMemberInfoRequest() {
+        given(kakaoRequestApi.requestMemberInfo(anyString()))
+                .willReturn(new KakaoMemberResponse(1L, "nickname",
+                        new KakaoMemberResponse.Properties("nickname"),
+                        new KakaoAccount(false, new KakaoAccount.Profile("nickname"), "email")
+                ));
     }
 }

--- a/src/test/java/com/baro/auth/presentation/oauth/OAuthApiTest.java
+++ b/src/test/java/com/baro/auth/presentation/oauth/OAuthApiTest.java
@@ -18,7 +18,7 @@ import com.baro.auth.infra.oauth.kakao.KakaoRequestApi;
 import com.baro.auth.infra.oauth.kakao.dto.KakaoMemberResponse;
 import com.baro.auth.infra.oauth.kakao.dto.KakaoMemberResponse.KakaoAccount;
 import com.baro.auth.infra.oauth.kakao.dto.KakaoTokenResponse;
-import com.baro.common.RestApiDocumentationTest;
+import com.baro.common.RestApiTest;
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
@@ -30,7 +30,7 @@ import org.springframework.http.HttpStatus;
 
 @DisplayNameGeneration(ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
-class OAuthApiDocumentTest extends RestApiDocumentationTest {
+class OAuthApiTest extends RestApiTest {
 
     @MockBean
     KakaoRequestApi kakaoRequestApi;

--- a/src/test/java/com/baro/auth/presentation/oauth/OAuthApiTest.java
+++ b/src/test/java/com/baro/auth/presentation/oauth/OAuthApiTest.java
@@ -1,109 +1,41 @@
 package com.baro.auth.presentation.oauth;
 
-import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.document;
-import static io.restassured.RestAssured.given;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.anyMap;
-import static org.mockito.Mockito.anyString;
-import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
-import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
-import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static com.baro.common.acceptance.AcceptanceSteps.리디렉션;
+import static com.baro.common.acceptance.AcceptanceSteps.성공;
+import static com.baro.common.acceptance.AcceptanceSteps.응답값을_검증한다;
+import static com.baro.common.acceptance.AcceptanceSteps.응답의_Location_헤더가_존재한다;
+import static com.baro.common.acceptance.auth.OAuthAcceptanceSteps.로그인_요청;
+import static com.baro.common.acceptance.auth.OAuthAcceptanceSteps.리다이렉트_URI_요청;
 
-import com.baro.auth.application.AuthService;
-import com.baro.auth.infra.oauth.kakao.KakaoOAuthClient;
-import com.baro.auth.infra.oauth.kakao.KakaoRequestApi;
-import com.baro.auth.infra.oauth.kakao.dto.KakaoMemberResponse;
-import com.baro.auth.infra.oauth.kakao.dto.KakaoMemberResponse.KakaoAccount;
-import com.baro.auth.infra.oauth.kakao.dto.KakaoTokenResponse;
+import com.baro.auth.fixture.OAuthMemberInfoFixture;
 import com.baro.common.RestApiTest;
-import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
 
 @DisplayNameGeneration(ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
 class OAuthApiTest extends RestApiTest {
 
-    @MockBean
-    KakaoRequestApi kakaoRequestApi;
-
-    @Autowired
-    KakaoOAuthClient oAuthClient;
-
-    @Autowired
-    AuthService authService;
-
     @Test
     void OAuth_로그인시_필요한_url을_반환한다() {
-        // given
-        var url = "/auth/oauth/{oauthType}";
-
         // when
-        var response = given(requestSpec).log().all()
-                .filter(document(DEFAULT_REST_DOCS_PATH,
-                        pathParameters(
-                                parameterWithName("oauthType").description("OAuth 로그인 소셜 타입")
-                        ),
-                        responseHeaders(
-                                headerWithName(HttpHeaders.LOCATION).description("로그인 url")
-                        ))
-                ).redirects().follow(false)
-                .when().get(url, "kakao")
-                .then().log().all()
-                .extract();
+        var 응답 = 리다이렉트_URI_요청("kakao");
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.MOVED_PERMANENTLY.value());
-        String location = new String(response.header("Location").getBytes(StandardCharsets.UTF_8));
-        assertThat(location).isNotNull();
+        응답값을_검증한다(응답, 리디렉션);
+        응답의_Location_헤더가_존재한다(응답);
     }
 
     @Test
     void OAuth로_로그인한다() {
         // given
-        var url = "/auth/oauth/sign-in/{oauthType}";
-
-        setOAuthTokenRequest();
-        setOAuthMemberInfoRequest();
+        OAuth_서버로부터_멤버_정보를_불러온다(OAuthMemberInfoFixture.유빈());
 
         // when
-        var response = given(requestSpec).log().all()
-                .filter(document(DEFAULT_REST_DOCS_PATH,
-                        pathParameters(
-                                parameterWithName("oauthType").description("OAuth 로그인 소셜 타입")
-                        ),
-                        queryParameters(
-                                parameterWithName("authCode").description("OAuth 소셜로그인 authcode")
-                        )
-                ))
-                .queryParam("authCode", "authCode")
-                .when().get(url, "kakao")
-                .then().log().all()
-                .extract();
+        var 응답 = 로그인_요청();
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-    }
-
-    private void setOAuthTokenRequest() {
-        given(kakaoRequestApi.requestToken(anyMap()))
-                .willReturn(new KakaoTokenResponse("Bearer", "accessToken", "idToken",
-                        1000, "refreshToken", 1000, "scope"));
-    }
-
-    private void setOAuthMemberInfoRequest() {
-        given(kakaoRequestApi.requestMemberInfo(anyString()))
-                .willReturn(new KakaoMemberResponse(1L, "nickname",
-                        new KakaoMemberResponse.Properties("nickname"),
-                        new KakaoAccount(false, new KakaoAccount.Profile("nickname"), "email")
-                ));
+        응답값을_검증한다(응답, 성공);
     }
 }

--- a/src/test/java/com/baro/auth/presentation/oauth/OAuthApiTest.java
+++ b/src/test/java/com/baro/auth/presentation/oauth/OAuthApiTest.java
@@ -1,5 +1,6 @@
 package com.baro.auth.presentation.oauth;
 
+import static com.baro.auth.fixture.OAuthMemberInfoFixture.유빈;
 import static com.baro.common.acceptance.AcceptanceSteps.리디렉션;
 import static com.baro.common.acceptance.AcceptanceSteps.성공;
 import static com.baro.common.acceptance.AcceptanceSteps.응답값을_검증한다;
@@ -7,7 +8,6 @@ import static com.baro.common.acceptance.AcceptanceSteps.응답의_Location_헤�
 import static com.baro.common.acceptance.auth.OAuthAcceptanceSteps.로그인_요청;
 import static com.baro.common.acceptance.auth.OAuthAcceptanceSteps.리다이렉트_URI_요청;
 
-import com.baro.auth.fixture.OAuthMemberInfoFixture;
 import com.baro.common.RestApiTest;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
@@ -30,7 +30,7 @@ class OAuthApiTest extends RestApiTest {
     @Test
     void OAuth로_로그인한다() {
         // given
-        OAuth_서버로부터_멤버_정보를_불러온다(OAuthMemberInfoFixture.유빈());
+        OAuth_서버로부터_멤버_정보를_불러온다(유빈());
 
         // when
         var 응답 = 로그인_요청();

--- a/src/test/java/com/baro/check/ActuatorTest.java
+++ b/src/test/java/com/baro/check/ActuatorTest.java
@@ -6,7 +6,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 
-import com.baro.common.RestApiDocumentationTest;
+import com.baro.common.RestApiTest;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
@@ -14,7 +14,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
 @DisplayNameGeneration(ReplaceUnderscores.class)
-public class ActuatorTest extends RestApiDocumentationTest {
+public class ActuatorTest extends RestApiTest {
 
     @Test
     void health_check() {

--- a/src/test/java/com/baro/check/ActuatorTest.java
+++ b/src/test/java/com/baro/check/ActuatorTest.java
@@ -7,10 +7,13 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWit
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 
 import com.baro.common.RestApiDocumentationTest;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
+@DisplayNameGeneration(ReplaceUnderscores.class)
 public class ActuatorTest extends RestApiDocumentationTest {
 
     @Test
@@ -22,7 +25,7 @@ public class ActuatorTest extends RestApiDocumentationTest {
         var response = given(requestSpec).log().all()
                 .filter(document(DEFAULT_REST_DOCS_PATH, responseFields(
                         fieldWithPath("status").description("상태")
-                        )))
+                )))
                 .accept(MediaType.APPLICATION_JSON_VALUE)
                 .header("Content-type", "application/json")
                 .when().get(url)

--- a/src/test/java/com/baro/check/ActuatorTest.java
+++ b/src/test/java/com/baro/check/ActuatorTest.java
@@ -1,40 +1,25 @@
 package com.baro.check;
 
-import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.document;
-import static io.restassured.RestAssured.given;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static com.baro.common.acceptance.AcceptanceSteps.성공;
+import static com.baro.common.acceptance.AcceptanceSteps.응답값을_검증한다;
+import static com.baro.common.acceptance.AcceptanceSteps.응답의_특정_필드값을_검증한다;
+import static com.baro.common.acceptance.check.ActuatorAcceptanceSteps.액추에이터_헬스체크_요청;
 
 import com.baro.common.RestApiTest;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 
 @DisplayNameGeneration(ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
 public class ActuatorTest extends RestApiTest {
 
     @Test
-    void health_check() {
-        // given
-        var url = "/actuator/health";
-
-        // when
-        var response = given(requestSpec).log().all()
-                .filter(document(DEFAULT_REST_DOCS_PATH, responseFields(
-                        fieldWithPath("status").description("상태")
-                )))
-                .accept(MediaType.APPLICATION_JSON_VALUE)
-                .header("Content-type", "application/json")
-                .when().get(url)
-                .then().log().all()
-                .extract();
+    void 헬스_체크() {
+        var 응답 = 액추에이터_헬스체크_요청();
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-        var message = response.body().jsonPath().getString("status");
-        assertThat(message).isEqualTo("UP");
+        응답값을_검증한다(응답, 성공);
+        응답의_특정_필드값을_검증한다(응답, "status", "UP");
     }
 }

--- a/src/test/java/com/baro/common/RestApiDocumentationTest.java
+++ b/src/test/java/com/baro/common/RestApiDocumentationTest.java
@@ -28,18 +28,15 @@ import org.springframework.restdocs.RestDocumentationExtension;
 public abstract class RestApiDocumentationTest {
 
     protected static final String DEFAULT_REST_DOCS_PATH = "{class_name}/{method_name}";
-
-    @LocalServerPort
-    private int port;
-
     protected RequestSpecification requestSpec;
-
     @Autowired
     protected JpaDataCleaner dataCleaner;
     @Autowired
     protected MemberRepository memberRepository;
     @Autowired
     protected MemoFolderRepository memoFolderRepository;
+    @LocalServerPort
+    private int port;
 
     @BeforeEach
     void setUp(final RestDocumentationContextProvider contextProvider) {

--- a/src/test/java/com/baro/common/RestApiTest.java
+++ b/src/test/java/com/baro/common/RestApiTest.java
@@ -3,6 +3,8 @@ package com.baro.common;
 import static com.baro.common.acceptance.auth.OAuthAcceptanceSteps.로그인_요청;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.restassured.RestAssuredRestDocumentation.documentationConfiguration;
 
 import com.baro.auth.application.oauth.OAuthInfoProvider;
 import com.baro.auth.application.oauth.dto.OAuthMemberInfo;
@@ -11,6 +13,10 @@ import com.baro.common.data.JpaDataCleaner;
 import com.baro.member.domain.MemberRepository;
 import com.baro.memofolder.domain.MemoFolderRepository;
 import io.restassured.RestAssured;
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.http.ContentType;
+import io.restassured.specification.RequestSpecification;
+import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,6 +26,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 
 @AutoConfigureRestDocs
@@ -27,6 +34,8 @@ import org.springframework.restdocs.RestDocumentationExtension;
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 public abstract class RestApiTest {
 
+    public static final String DEFAULT_REST_DOCS_PATH = "{class_name}/{method_name}";
+    public static RequestSpecification requestSpec;
     @Autowired
     protected JpaDataCleaner dataCleaner;
     @Autowired
@@ -39,8 +48,16 @@ public abstract class RestApiTest {
     private int port;
 
     @BeforeEach
-    void setUp() {
+    void setUp(RestDocumentationContextProvider contextProvider) {
         RestAssured.port = port;
+        requestSpec = new RequestSpecBuilder()
+                .setPort(port)
+                .setContentType(ContentType.JSON.withCharset(StandardCharsets.UTF_8))
+                .addFilter(documentationConfiguration(contextProvider)
+                        .operationPreprocessors()
+                        .withRequestDefaults(prettyPrint())
+                        .withResponseDefaults(prettyPrint())
+                ).build();
     }
 
     @AfterEach

--- a/src/test/java/com/baro/common/RestApiTest.java
+++ b/src/test/java/com/baro/common/RestApiTest.java
@@ -25,7 +25,7 @@ import org.springframework.restdocs.RestDocumentationExtension;
 @AutoConfigureRestDocs
 @ExtendWith(RestDocumentationExtension.class)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
-public abstract class RestApiDocumentationTest {
+public abstract class RestApiTest {
 
     protected static final String DEFAULT_REST_DOCS_PATH = "{class_name}/{method_name}";
     protected RequestSpecification requestSpec;

--- a/src/test/java/com/baro/common/RestApiTest.java
+++ b/src/test/java/com/baro/common/RestApiTest.java
@@ -10,8 +10,6 @@ import com.baro.auth.application.oauth.OAuthInfoProvider;
 import com.baro.auth.application.oauth.dto.OAuthMemberInfo;
 import com.baro.auth.domain.Token;
 import com.baro.common.data.JpaDataCleaner;
-import com.baro.member.domain.MemberRepository;
-import com.baro.memofolder.domain.MemoFolderRepository;
 import io.restassured.RestAssured;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.http.ContentType;
@@ -38,10 +36,6 @@ public abstract class RestApiTest {
     public static RequestSpecification requestSpec;
     @Autowired
     protected JpaDataCleaner dataCleaner;
-    @Autowired
-    protected MemberRepository memberRepository;
-    @Autowired
-    protected MemoFolderRepository memoFolderRepository;
     @SpyBean
     OAuthInfoProvider oAuthInfoProvider;
     @LocalServerPort

--- a/src/test/java/com/baro/common/RestApiTest.java
+++ b/src/test/java/com/baro/common/RestApiTest.java
@@ -1,16 +1,16 @@
 package com.baro.common;
 
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
-import static org.springframework.restdocs.restassured.RestAssuredRestDocumentation.documentationConfiguration;
+import static com.baro.common.acceptance.auth.OAuthAcceptanceSteps.로그인_요청;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
 
+import com.baro.auth.application.oauth.OAuthInfoProvider;
+import com.baro.auth.application.oauth.dto.OAuthMemberInfo;
+import com.baro.auth.domain.Token;
 import com.baro.common.data.JpaDataCleaner;
 import com.baro.member.domain.MemberRepository;
 import com.baro.memofolder.domain.MemoFolderRepository;
 import io.restassured.RestAssured;
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.http.ContentType;
-import io.restassured.specification.RequestSpecification;
-import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,8 +18,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.boot.test.web.server.LocalServerPort;
-import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 
 @AutoConfigureRestDocs
@@ -27,32 +27,33 @@ import org.springframework.restdocs.RestDocumentationExtension;
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 public abstract class RestApiTest {
 
-    protected static final String DEFAULT_REST_DOCS_PATH = "{class_name}/{method_name}";
-    protected RequestSpecification requestSpec;
     @Autowired
     protected JpaDataCleaner dataCleaner;
     @Autowired
     protected MemberRepository memberRepository;
     @Autowired
     protected MemoFolderRepository memoFolderRepository;
+    @SpyBean
+    OAuthInfoProvider oAuthInfoProvider;
     @LocalServerPort
     private int port;
 
     @BeforeEach
-    void setUp(final RestDocumentationContextProvider contextProvider) {
+    void setUp() {
         RestAssured.port = port;
-        requestSpec = new RequestSpecBuilder()
-                .setPort(port)
-                .setContentType(ContentType.JSON.withCharset(StandardCharsets.UTF_8))
-                .addFilter(documentationConfiguration(contextProvider)
-                        .operationPreprocessors()
-                        .withRequestDefaults(prettyPrint())
-                        .withResponseDefaults(prettyPrint())
-                ).build();
     }
 
     @AfterEach
     void cleanUp() {
         dataCleaner.cleanUp();
+    }
+
+    protected Token 로그인(OAuthMemberInfo memberInfo) {
+        OAuth_서버로부터_멤버_정보를_불러온다(memberInfo);
+        return 로그인_요청().as(Token.class);
+    }
+
+    protected void OAuth_서버로부터_멤버_정보를_불러온다(OAuthMemberInfo memberInfo) {
+        doReturn(memberInfo).when(oAuthInfoProvider).getMemberInfo(anyString(), anyString());
     }
 }

--- a/src/test/java/com/baro/common/acceptance/AcceptanceSteps.java
+++ b/src/test/java/com/baro/common/acceptance/AcceptanceSteps.java
@@ -1,0 +1,37 @@
+package com.baro.common.acceptance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.nio.charset.StandardCharsets;
+import org.springframework.http.HttpStatus;
+
+public class AcceptanceSteps {
+
+    public static final HttpStatus 성공 = HttpStatus.OK;
+    public static final HttpStatus 생성됨 = HttpStatus.CREATED;
+    public static final HttpStatus 리디렉션 = HttpStatus.MOVED_PERMANENTLY;
+    public static final HttpStatus 잘못된_요청 = HttpStatus.BAD_REQUEST;
+
+    public static void 응답값을_검증한다(
+            ExtractableResponse<Response> 응답,
+            HttpStatus 예상상태
+    ) {
+        assertThat(응답.statusCode()).isEqualTo(예상상태.value());
+    }
+
+    public static void 응답의_Location_헤더가_존재한다(
+            ExtractableResponse<Response> 응답
+    ) {
+        assertThat(응답.header("Location").getBytes(StandardCharsets.UTF_8)).isNotNull();
+    }
+
+    public static void 응답의_특정_필드값을_검증한다(
+            ExtractableResponse<Response> 응답,
+            String 필드,
+            Object 값
+    ) {
+        assertThat(응답.body().jsonPath().getString(필드)).isEqualTo(값);
+    }
+}

--- a/src/test/java/com/baro/common/acceptance/auth/AuthAcceptanceSteps.java
+++ b/src/test/java/com/baro/common/acceptance/auth/AuthAcceptanceSteps.java
@@ -1,6 +1,13 @@
 package com.baro.common.acceptance.auth;
 
+import static com.baro.common.RestApiTest.DEFAULT_REST_DOCS_PATH;
+import static com.baro.common.RestApiTest.requestSpec;
+import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.document;
 import static io.restassured.RestAssured.given;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 
 import com.baro.auth.domain.Token;
 import io.restassured.response.ExtractableResponse;
@@ -13,7 +20,37 @@ public class AuthAcceptanceSteps {
     public static ExtractableResponse<Response> 토큰_재발급_요청(Token token) {
         var url = "/auth/reissue";
 
-        return given().log().all()
+        return given(requestSpec).log().all()
+                .filter(document(DEFAULT_REST_DOCS_PATH,
+                        queryParameters(
+                                parameterWithName("refreshToken").description("refreshToken")
+                        ),
+                        responseFields(
+                                fieldWithPath("accessToken").description("액세스 토큰"),
+                                fieldWithPath("refreshToken").description("리프레시 토큰")
+                        ))
+                )
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token.accessToken())
+                .queryParam("refreshToken", "Bearer " + token.refreshToken())
+                .when().get(url)
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 잘못된_토큰_재발급_요청(Token token) {
+        var url = "/auth/reissue";
+
+        return given(requestSpec).log().all()
+                .filter(document(DEFAULT_REST_DOCS_PATH,
+                        queryParameters(
+                                parameterWithName("refreshToken").description("refreshToken")
+                        ),
+                        responseFields(
+                                fieldWithPath("errorCode").description("에러 코드"),
+                                fieldWithPath("errorMessage").description("에러 메시지")
+                        ))
+                )
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + token.accessToken())
                 .queryParam("refreshToken", "Bearer " + token.refreshToken())
@@ -25,7 +62,16 @@ public class AuthAcceptanceSteps {
     public static ExtractableResponse<Response> Bearer_타입이_아닌_토큰_재발급_요청(Token token) {
         var url = "/auth/reissue";
 
-        return given().log().all()
+        return given(requestSpec).log().all()
+                .filter(document(DEFAULT_REST_DOCS_PATH,
+                        queryParameters(
+                                parameterWithName("refreshToken").description("refreshToken")
+                        ),
+                        responseFields(
+                                fieldWithPath("errorCode").description("에러 코드"),
+                                fieldWithPath("errorMessage").description("에러 메시지")
+                        ))
+                )
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + token.accessToken())
                 .queryParam("refreshToken", "Basic " + token.refreshToken())

--- a/src/test/java/com/baro/common/acceptance/auth/AuthAcceptanceSteps.java
+++ b/src/test/java/com/baro/common/acceptance/auth/AuthAcceptanceSteps.java
@@ -1,0 +1,36 @@
+package com.baro.common.acceptance.auth;
+
+import static io.restassured.RestAssured.given;
+
+import com.baro.auth.domain.Token;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+public class AuthAcceptanceSteps {
+
+    public static ExtractableResponse<Response> 토큰_재발급_요청(Token token) {
+        var url = "/auth/reissue";
+
+        return given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token.accessToken())
+                .queryParam("refreshToken", "Bearer " + token.refreshToken())
+                .when().get(url)
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> Bearer_타입이_아닌_토큰_재발급_요청(Token token) {
+        var url = "/auth/reissue";
+
+        return given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token.accessToken())
+                .queryParam("refreshToken", "Basic " + token.refreshToken())
+                .when().get(url)
+                .then().log().all()
+                .extract();
+    }
+}

--- a/src/test/java/com/baro/common/acceptance/auth/OAuthAcceptanceSteps.java
+++ b/src/test/java/com/baro/common/acceptance/auth/OAuthAcceptanceSteps.java
@@ -1,0 +1,32 @@
+package com.baro.common.acceptance.auth;
+
+import static io.restassured.RestAssured.given;
+
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.springframework.http.MediaType;
+
+public class OAuthAcceptanceSteps {
+
+    public static ExtractableResponse<Response> 리다이렉트_URI_요청(String oauthServiceType) {
+        var url = "/auth/oauth/{oauthType}";
+
+        return given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .redirects().follow(false)
+                .when().get(url, oauthServiceType)
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 로그인_요청() {
+        var url = "/auth/oauth/sign-in/{oauthType}";
+
+        return given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .queryParam("authCode", "authCode")
+                .when().get(url, "kakao")
+                .then().log().all()
+                .extract();
+    }
+}

--- a/src/test/java/com/baro/common/acceptance/auth/OAuthAcceptanceSteps.java
+++ b/src/test/java/com/baro/common/acceptance/auth/OAuthAcceptanceSteps.java
@@ -1,9 +1,18 @@
 package com.baro.common.acceptance.auth;
 
+import static com.baro.common.RestApiTest.DEFAULT_REST_DOCS_PATH;
+import static com.baro.common.RestApiTest.requestSpec;
+import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.document;
 import static io.restassured.RestAssured.given;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 
 public class OAuthAcceptanceSteps {
@@ -11,7 +20,15 @@ public class OAuthAcceptanceSteps {
     public static ExtractableResponse<Response> 리다이렉트_URI_요청(String oauthServiceType) {
         var url = "/auth/oauth/{oauthType}";
 
-        return given().log().all()
+        return given(requestSpec).log().all()
+                .filter(document(DEFAULT_REST_DOCS_PATH,
+                        pathParameters(
+                                parameterWithName("oauthType").description("OAuth 로그인 소셜 타입")
+                        ),
+                        responseHeaders(
+                                headerWithName(HttpHeaders.LOCATION).description("로그인 url")
+                        ))
+                )
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .redirects().follow(false)
                 .when().get(url, oauthServiceType)
@@ -22,7 +39,15 @@ public class OAuthAcceptanceSteps {
     public static ExtractableResponse<Response> 로그인_요청() {
         var url = "/auth/oauth/sign-in/{oauthType}";
 
-        return given().log().all()
+        return given(requestSpec).log().all()
+                .filter(document(DEFAULT_REST_DOCS_PATH,
+                        pathParameters(
+                                parameterWithName("oauthType").description("OAuth 로그인 소셜 타입")
+                        ),
+                        queryParameters(
+                                parameterWithName("authCode").description("OAuth 소셜로그인 authcode")
+                        )
+                ))
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .queryParam("authCode", "authCode")
                 .when().get(url, "kakao")

--- a/src/test/java/com/baro/common/acceptance/check/ActuatorAcceptanceSteps.java
+++ b/src/test/java/com/baro/common/acceptance/check/ActuatorAcceptanceSteps.java
@@ -1,0 +1,21 @@
+package com.baro.common.acceptance.check;
+
+import static io.restassured.RestAssured.given;
+
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.springframework.http.MediaType;
+
+public class ActuatorAcceptanceSteps {
+
+    public static ExtractableResponse<Response> 액추에이터_헬스체크_요청() {
+        var url = "/actuator/health";
+
+        return given().log().all()
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .header("Content-type", "application/json")
+                .when().get(url)
+                .then().log().all()
+                .extract();
+    }
+}

--- a/src/test/java/com/baro/common/acceptance/memofolder/MemoFolderAcceptanceSteps.java
+++ b/src/test/java/com/baro/common/acceptance/memofolder/MemoFolderAcceptanceSteps.java
@@ -1,0 +1,35 @@
+package com.baro.common.acceptance.memofolder;
+
+import static io.restassured.RestAssured.given;
+
+import com.baro.auth.domain.Token;
+import com.baro.memofolder.presentation.dto.SaveMemoFolderRequest;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+public class MemoFolderAcceptanceSteps {
+
+    public static ExtractableResponse<Response> 메모_폴더_생성_요청(Token 토큰, SaveMemoFolderRequest 바디) {
+        var url = "/memo-folders";
+
+        return given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + 토큰.accessToken()).body(바디)
+                .when().post(url)
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 메모_폴더_불러오기_요청(Token 토큰) {
+        var url = "/memo-folders";
+
+        return given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + 토큰.accessToken())
+                .when().get(url)
+                .then().log().all()
+                .extract();
+    }
+}

--- a/src/test/java/com/baro/common/acceptance/memofolder/MemoFolderAcceptanceSteps.java
+++ b/src/test/java/com/baro/common/acceptance/memofolder/MemoFolderAcceptanceSteps.java
@@ -1,6 +1,15 @@
 package com.baro.common.acceptance.memofolder;
 
+import static com.baro.common.RestApiTest.DEFAULT_REST_DOCS_PATH;
+import static com.baro.common.RestApiTest.requestSpec;
+import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.document;
 import static io.restassured.RestAssured.given;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 
 import com.baro.auth.domain.Token;
 import com.baro.memofolder.presentation.dto.SaveMemoFolderRequest;
@@ -14,7 +23,41 @@ public class MemoFolderAcceptanceSteps {
     public static ExtractableResponse<Response> 메모_폴더_생성_요청(Token 토큰, SaveMemoFolderRequest 바디) {
         var url = "/memo-folders";
 
-        return given().log().all()
+        return given(requestSpec).log().all()
+                .filter(document(DEFAULT_REST_DOCS_PATH,
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("인증 토큰")
+                        ),
+                        responseHeaders(
+                                headerWithName(HttpHeaders.LOCATION).description("생성된 폴더 경로")
+                        ),
+                        requestFields(
+                                fieldWithPath("folderName").description("폴더 이름")
+                        ))
+                )
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + 토큰.accessToken()).body(바디)
+                .when().post(url)
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 잘못된_메모_폴더_생성_요청(Token 토큰, SaveMemoFolderRequest 바디) {
+        var url = "/memo-folders";
+
+        return given(requestSpec).log().all()
+                .filter(document(DEFAULT_REST_DOCS_PATH,
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("인증 토큰")
+                        ),
+                        requestFields(
+                                fieldWithPath("folderName").description("폴더 이름")
+                        ),
+                        responseFields(
+                                fieldWithPath("errorCode").description("에러 코드"),
+                                fieldWithPath("errorMessage").description("에러 메시지")
+                        ))
+                )
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + 토큰.accessToken()).body(바디)
                 .when().post(url)
@@ -25,7 +68,16 @@ public class MemoFolderAcceptanceSteps {
     public static ExtractableResponse<Response> 메모_폴더_불러오기_요청(Token 토큰) {
         var url = "/memo-folders";
 
-        return given().log().all()
+        return given(requestSpec).log().all()
+                .filter(document(DEFAULT_REST_DOCS_PATH,
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("인증 토큰")
+                        ),
+                        responseFields(
+                                fieldWithPath("[].id").description("폴더 id"),
+                                fieldWithPath("[].name").description("폴더 이름")
+                        ))
+                )
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + 토큰.accessToken())
                 .when().get(url)

--- a/src/test/java/com/baro/common/config/RedisPropertyTest.java
+++ b/src/test/java/com/baro/common/config/RedisPropertyTest.java
@@ -3,11 +3,14 @@ package com.baro.common.config;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Objects;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 
+@DisplayNameGeneration(ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
 @SpringBootTest(webEnvironment = WebEnvironment.NONE)
 class RedisPropertyTest {

--- a/src/test/java/com/baro/common/time/fake/FakeTimeServer.java
+++ b/src/test/java/com/baro/common/time/fake/FakeTimeServer.java
@@ -1,12 +1,11 @@
 package com.baro.common.time.fake;
 
 import com.baro.common.time.TimeServer;
-
 import java.time.Instant;
 
 public class FakeTimeServer implements TimeServer {
 
-    private Instant now;
+    private final Instant now;
 
     public FakeTimeServer(Instant now) {
         this.now = now;

--- a/src/test/java/com/baro/common/utils/EmojiUtilsTest.java
+++ b/src/test/java/com/baro/common/utils/EmojiUtilsTest.java
@@ -2,9 +2,12 @@ package com.baro.common.utils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
+@DisplayNameGeneration(ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
 class EmojiUtilsTest {
 

--- a/src/test/java/com/baro/member/application/MemberCreatorTest.java
+++ b/src/test/java/com/baro/member/application/MemberCreatorTest.java
@@ -1,17 +1,20 @@
 package com.baro.member.application;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.baro.member.domain.Member;
 import com.baro.member.domain.MemberRepository;
 import com.baro.member.fake.FakeMemberRepository;
 import com.baro.member.fake.FakeNicknameCreator;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
 import java.util.List;
 import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
 class MemberCreatorTest {
 
     NicknameCreator uniqueNicknameCreator;

--- a/src/test/java/com/baro/member/fake/FakeNicknameCreator.java
+++ b/src/test/java/com/baro/member/fake/FakeNicknameCreator.java
@@ -1,14 +1,13 @@
 package com.baro.member.fake;
 
 import com.baro.member.application.NicknameCreator;
-
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
 
 public class FakeNicknameCreator implements NicknameCreator {
 
-    private Queue<String> nicknames;
+    private final Queue<String> nicknames;
 
     public FakeNicknameCreator(List<String> nicknames) {
         this.nicknames = new LinkedList<>(nicknames);

--- a/src/test/java/com/baro/memofolder/domain/MemoFolderNameTest.java
+++ b/src/test/java/com/baro/memofolder/domain/MemoFolderNameTest.java
@@ -5,8 +5,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.baro.memofolder.exception.MemoFolderException;
 import com.baro.memofolder.exception.MemoFolderExceptionType;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
 
+@DisplayNameGeneration(ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
 class MemoFolderNameTest {
 

--- a/src/test/java/com/baro/memofolder/presentation/MemoFolderApiDocumentTest.java
+++ b/src/test/java/com/baro/memofolder/presentation/MemoFolderApiDocumentTest.java
@@ -18,11 +18,15 @@ import com.baro.member.fixture.MemberFixture;
 import com.baro.memofolder.domain.MemoFolder;
 import com.baro.memofolder.presentation.dto.SaveMemoFolderRequest;
 import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
 class MemoFolderApiDocumentTest extends RestApiDocumentationTest {
 
     private static final String SET_UP_ACCESS_TOKEN = "accessToken";

--- a/src/test/java/com/baro/memofolder/presentation/MemoFolderApiTest.java
+++ b/src/test/java/com/baro/memofolder/presentation/MemoFolderApiTest.java
@@ -35,7 +35,7 @@ class MemoFolderApiTest extends RestApiTest {
     TokenTranslator tokenTranslator;
 
     @Test
-    void create_memo_folder() {
+    void 메모_폴더를_생성한다() {
         // given
         var url = "/memo-folders";
         var request = new SaveMemoFolderRequest("회사생활👔");
@@ -66,7 +66,7 @@ class MemoFolderApiTest extends RestApiTest {
     }
 
     @Test
-    void create_memo_folder_duplication() {
+    void 중복되는_이름의_폴더를_생성하는_경우_예외를_반환한다() {
         // given
         var url = "/memo-folders";
         String duplicationName = "회사생활👔";
@@ -98,7 +98,7 @@ class MemoFolderApiTest extends RestApiTest {
     }
 
     @Test
-    void create_memo_folder_not_exist_member() {
+    void 존재하지_않는_멤버가_폴더를_생성하는_경우_예외를_반환한다() {
         // given
         var url = "/memo-folders";
         var request = new SaveMemoFolderRequest("회사생활👔");
@@ -127,7 +127,7 @@ class MemoFolderApiTest extends RestApiTest {
     }
 
     @Test
-    void create_memo_folder_over_max_size_name() {
+    void 최대치_이름_길이를_초과하는_폴더를_생성하는_경우_예외를_반환한다() {
         // given
         var url = "/memo-folders";
         var request = new SaveMemoFolderRequest("회사생활은재미없겠지만해야겠지👔👔👔");
@@ -157,7 +157,7 @@ class MemoFolderApiTest extends RestApiTest {
     }
 
     @Test
-    void get_memo_folders() {
+    void 메모_폴더를_불러온다() {
         // given
         var url = "/memo-folders";
         Member savedMember = memberRepository.save(MemberFixture.memberWithNickname("바로"));

--- a/src/test/java/com/baro/memofolder/presentation/MemoFolderApiTest.java
+++ b/src/test/java/com/baro/memofolder/presentation/MemoFolderApiTest.java
@@ -1,5 +1,10 @@
 package com.baro.memofolder.presentation;
 
+import static com.baro.auth.fixture.OAuthMemberInfoFixture.동균;
+import static com.baro.auth.fixture.OAuthMemberInfoFixture.원진;
+import static com.baro.auth.fixture.OAuthMemberInfoFixture.유빈;
+import static com.baro.auth.fixture.OAuthMemberInfoFixture.은지;
+import static com.baro.auth.fixture.OAuthMemberInfoFixture.태연;
 import static com.baro.common.acceptance.AcceptanceSteps.생성됨;
 import static com.baro.common.acceptance.AcceptanceSteps.성공;
 import static com.baro.common.acceptance.AcceptanceSteps.응답값을_검증한다;
@@ -11,7 +16,6 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.willThrow;
 
 import com.baro.auth.domain.Token;
-import com.baro.auth.fixture.OAuthMemberInfoFixture;
 import com.baro.common.RestApiTest;
 import com.baro.member.domain.MemberRepository;
 import com.baro.member.exception.MemberException;
@@ -26,14 +30,16 @@ import org.springframework.boot.test.mock.mockito.SpyBean;
 @SuppressWarnings("NonAsciiCharacters")
 class MemoFolderApiTest extends RestApiTest {
 
+    private final SaveMemoFolderRequest 정상_바디 = new SaveMemoFolderRequest("회사생활👔");
+    private final SaveMemoFolderRequest 폴더_이름_길이_초과_바디 = new SaveMemoFolderRequest("회사생활은재미없겠지만해야겠지👔👔👔");
     @SpyBean
     MemberRepository memberRepository;
 
     @Test
     void 메모_폴더를_생성한다() {
         // given
-        var 요청_바디 = new SaveMemoFolderRequest("회사생활👔");
-        var 토큰 = 로그인(OAuthMemberInfoFixture.태연());
+        var 요청_바디 = 정상_바디;
+        var 토큰 = 로그인(태연());
 
         // when
         var 응답 = 메모_폴더_생성_요청(토큰, 요청_바디);
@@ -46,8 +52,8 @@ class MemoFolderApiTest extends RestApiTest {
     @Test
     void 중복되는_이름의_폴더를_생성하는_경우_예외를_반환한다() {
         // given
-        var 요청_바디 = new SaveMemoFolderRequest("회사생활👔");
-        var 토큰 = 로그인(OAuthMemberInfoFixture.유빈());
+        var 요청_바디 = 정상_바디;
+        var 토큰 = 로그인(유빈());
         메모_폴더_생성_요청(토큰, 요청_바디);
 
         // when
@@ -60,9 +66,8 @@ class MemoFolderApiTest extends RestApiTest {
     @Test
     void 존재하지_않는_멤버가_폴더를_생성하는_경우_예외를_반환한다() {
         // given
-        var 요청_바디 = new SaveMemoFolderRequest("회사생활👔");
-        var 동균 = OAuthMemberInfoFixture.동균();
-        var 토큰 = 로그인(동균);
+        var 요청_바디 = 정상_바디;
+        var 토큰 = 로그인(동균());
         멤버가_존재하지_않는다();
 
         // when
@@ -75,8 +80,8 @@ class MemoFolderApiTest extends RestApiTest {
     @Test
     void 최대치_이름_길이를_초과하는_폴더를_생성하는_경우_예외를_반환한다() {
         // given
-        var 요청_바디 = new SaveMemoFolderRequest("회사생활은재미없겠지만해야겠지👔👔👔");
-        var 토큰 = 로그인(OAuthMemberInfoFixture.은지());
+        var 요청_바디 = 폴더_이름_길이_초과_바디;
+        var 토큰 = 로그인(은지());
 
         // when
         var 응답 = 메모_폴더_생성_요청(토큰, 요청_바디);
@@ -88,8 +93,8 @@ class MemoFolderApiTest extends RestApiTest {
     @Test
     void 메모_폴더를_불러온다() {
         // given
-        Token 토큰 = 로그인(OAuthMemberInfoFixture.원진());
-        메모_폴더_생성_요청(토큰, new SaveMemoFolderRequest("회사생활👔"));
+        Token 토큰 = 로그인(원진());
+        메모_폴더_생성_요청(토큰, 정상_바디);
 
         // when
         var 응답 = 메모_폴더_불러오기_요청(토큰);

--- a/src/test/java/com/baro/memofolder/presentation/MemoFolderApiTest.java
+++ b/src/test/java/com/baro/memofolder/presentation/MemoFolderApiTest.java
@@ -12,6 +12,7 @@ import static com.baro.common.acceptance.AcceptanceSteps.응답의_Location_헤�
 import static com.baro.common.acceptance.AcceptanceSteps.잘못된_요청;
 import static com.baro.common.acceptance.memofolder.MemoFolderAcceptanceSteps.메모_폴더_불러오기_요청;
 import static com.baro.common.acceptance.memofolder.MemoFolderAcceptanceSteps.메모_폴더_생성_요청;
+import static com.baro.common.acceptance.memofolder.MemoFolderAcceptanceSteps.잘못된_메모_폴더_생성_요청;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.willThrow;
 
@@ -57,7 +58,7 @@ class MemoFolderApiTest extends RestApiTest {
         메모_폴더_생성_요청(토큰, 요청_바디);
 
         // when
-        var 응답 = 메모_폴더_생성_요청(토큰, 요청_바디);
+        var 응답 = 잘못된_메모_폴더_생성_요청(토큰, 요청_바디);
 
         // then
         응답값을_검증한다(응답, 잘못된_요청);
@@ -71,7 +72,7 @@ class MemoFolderApiTest extends RestApiTest {
         멤버가_존재하지_않는다();
 
         // when
-        var 응답 = 메모_폴더_생성_요청(토큰, 요청_바디);
+        var 응답 = 잘못된_메모_폴더_생성_요청(토큰, 요청_바디);
 
         // then
         응답값을_검증한다(응답, 잘못된_요청);
@@ -84,7 +85,7 @@ class MemoFolderApiTest extends RestApiTest {
         var 토큰 = 로그인(은지());
 
         // when
-        var 응답 = 메모_폴더_생성_요청(토큰, 요청_바디);
+        var 응답 = 잘못된_메모_폴더_생성_요청(토큰, 요청_바디);
 
         // then
         응답값을_검증한다(응답, 잘못된_요청);

--- a/src/test/java/com/baro/memofolder/presentation/MemoFolderApiTest.java
+++ b/src/test/java/com/baro/memofolder/presentation/MemoFolderApiTest.java
@@ -8,7 +8,7 @@ import static com.baro.common.acceptance.AcceptanceSteps.잘못된_요청;
 import static com.baro.common.acceptance.memofolder.MemoFolderAcceptanceSteps.메모_폴더_불러오기_요청;
 import static com.baro.common.acceptance.memofolder.MemoFolderAcceptanceSteps.메모_폴더_생성_요청;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.doThrow;
+import static org.mockito.BDDMockito.willThrow;
 
 import com.baro.auth.domain.Token;
 import com.baro.auth.fixture.OAuthMemberInfoFixture;
@@ -99,6 +99,6 @@ class MemoFolderApiTest extends RestApiTest {
     }
 
     void 멤버가_존재하지_않는다() {
-        doThrow(new MemberException(MemberExceptionType.NOT_EXIST_MEMBER)).when(memberRepository).getById(anyLong());
+        willThrow(new MemberException(MemberExceptionType.NOT_EXIST_MEMBER)).given(memberRepository).getById(anyLong());
     }
 }

--- a/src/test/java/com/baro/memofolder/presentation/MemoFolderApiTest.java
+++ b/src/test/java/com/baro/memofolder/presentation/MemoFolderApiTest.java
@@ -16,7 +16,6 @@ import static com.baro.common.acceptance.memofolder.MemoFolderAcceptanceSteps.�
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.willThrow;
 
-import com.baro.auth.domain.Token;
 import com.baro.common.RestApiTest;
 import com.baro.member.domain.MemberRepository;
 import com.baro.member.exception.MemberException;
@@ -94,7 +93,7 @@ class MemoFolderApiTest extends RestApiTest {
     @Test
     void 메모_폴더를_불러온다() {
         // given
-        Token 토큰 = 로그인(원진());
+        var 토큰 = 로그인(원진());
         메모_폴더_생성_요청(토큰, 정상_바디);
 
         // when

--- a/src/test/java/com/baro/memofolder/presentation/MemoFolderApiTest.java
+++ b/src/test/java/com/baro/memofolder/presentation/MemoFolderApiTest.java
@@ -1,194 +1,104 @@
 package com.baro.memofolder.presentation;
 
-import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.document;
-import static io.restassured.RestAssured.given;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
-import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
-import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
-import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static com.baro.common.acceptance.AcceptanceSteps.생성됨;
+import static com.baro.common.acceptance.AcceptanceSteps.성공;
+import static com.baro.common.acceptance.AcceptanceSteps.응답값을_검증한다;
+import static com.baro.common.acceptance.AcceptanceSteps.응답의_Location_헤더가_존재한다;
+import static com.baro.common.acceptance.AcceptanceSteps.잘못된_요청;
+import static com.baro.common.acceptance.memofolder.MemoFolderAcceptanceSteps.메모_폴더_불러오기_요청;
+import static com.baro.common.acceptance.memofolder.MemoFolderAcceptanceSteps.메모_폴더_생성_요청;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doThrow;
 
-import com.baro.auth.application.TokenTranslator;
+import com.baro.auth.domain.Token;
+import com.baro.auth.fixture.OAuthMemberInfoFixture;
 import com.baro.common.RestApiTest;
-import com.baro.member.domain.Member;
-import com.baro.member.fixture.MemberFixture;
-import com.baro.memofolder.domain.MemoFolder;
+import com.baro.member.domain.MemberRepository;
+import com.baro.member.exception.MemberException;
+import com.baro.member.exception.MemberExceptionType;
 import com.baro.memofolder.presentation.dto.SaveMemoFolderRequest;
-import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 
 @DisplayNameGeneration(ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
 class MemoFolderApiTest extends RestApiTest {
 
-    private static final String SET_UP_ACCESS_TOKEN = "accessToken";
-
-    @MockBean
-    TokenTranslator tokenTranslator;
+    @SpyBean
+    MemberRepository memberRepository;
 
     @Test
     void 메모_폴더를_생성한다() {
         // given
-        var url = "/memo-folders";
-        var request = new SaveMemoFolderRequest("회사생활👔");
-        Member savedMember = memberRepository.save(MemberFixture.memberWithNickname("바로"));
-        setTokenDecrypt(savedMember);
+        var 요청_바디 = new SaveMemoFolderRequest("회사생활👔");
+        var 토큰 = 로그인(OAuthMemberInfoFixture.태연());
 
         // when
-        var response = given(requestSpec).log().all()
-                .filter(document(DEFAULT_REST_DOCS_PATH,
-                        requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("인증 토큰")
-                        ),
-                        responseHeaders(
-                                headerWithName(HttpHeaders.LOCATION).description("생성된 폴더 경로")
-                        ),
-                        requestFields(
-                                fieldWithPath("folderName").description("폴더 이름")
-                        ))
-                ).header(HttpHeaders.AUTHORIZATION, SET_UP_ACCESS_TOKEN).body(request)
-                .when().post(url)
-                .then().log().all()
-                .extract();
+        var 응답 = 메모_폴더_생성_요청(토큰, 요청_바디);
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
-        String location = new String(response.header("Location").getBytes(StandardCharsets.UTF_8));
-        assertThat(location).isNotNull();
+        응답값을_검증한다(응답, 생성됨);
+        응답의_Location_헤더가_존재한다(응답);
     }
 
     @Test
     void 중복되는_이름의_폴더를_생성하는_경우_예외를_반환한다() {
         // given
-        var url = "/memo-folders";
-        String duplicationName = "회사생활👔";
-        var request = new SaveMemoFolderRequest(duplicationName);
-        Member savedMember = memberRepository.save(MemberFixture.memberWithNickname("바로"));
-        setTokenDecrypt(savedMember);
-        memoFolderRepository.save(MemoFolder.of(savedMember, duplicationName));
+        var 요청_바디 = new SaveMemoFolderRequest("회사생활👔");
+        var 토큰 = 로그인(OAuthMemberInfoFixture.유빈());
+        메모_폴더_생성_요청(토큰, 요청_바디);
 
         // when
-        var response = given(requestSpec).log().all()
-                .filter(document(DEFAULT_REST_DOCS_PATH,
-                        requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("인증 토큰")
-                        ),
-                        requestFields(
-                                fieldWithPath("folderName").description("폴더 이름")
-                        ),
-                        responseFields(
-                                fieldWithPath("errorCode").description("에러 코드"),
-                                fieldWithPath("errorMessage").description("에러 메시지")
-                        ))
-                ).header(HttpHeaders.AUTHORIZATION, SET_UP_ACCESS_TOKEN).body(request)
-                .when().post(url)
-                .then().log().all()
-                .extract();
+        var 응답 = 메모_폴더_생성_요청(토큰, 요청_바디);
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        응답값을_검증한다(응답, 잘못된_요청);
     }
 
     @Test
     void 존재하지_않는_멤버가_폴더를_생성하는_경우_예외를_반환한다() {
         // given
-        var url = "/memo-folders";
-        var request = new SaveMemoFolderRequest("회사생활👔");
-        setTokenDecryptAsNotExistMember();
+        var 요청_바디 = new SaveMemoFolderRequest("회사생활👔");
+        var 동균 = OAuthMemberInfoFixture.동균();
+        var 토큰 = 로그인(동균);
+        멤버가_존재하지_않는다();
 
         // when
-        var response = given(requestSpec).log().all()
-                .filter(document(DEFAULT_REST_DOCS_PATH,
-                        requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("인증 토큰")
-                        ),
-                        requestFields(
-                                fieldWithPath("folderName").description("폴더 이름")
-                        ),
-                        responseFields(
-                                fieldWithPath("errorCode").description("에러 코드"),
-                                fieldWithPath("errorMessage").description("에러 메시지")
-                        ))
-                ).header(HttpHeaders.AUTHORIZATION, SET_UP_ACCESS_TOKEN).body(request)
-                .when().post(url)
-                .then().log().all()
-                .extract();
+        var 응답 = 메모_폴더_생성_요청(토큰, 요청_바디);
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        응답값을_검증한다(응답, 잘못된_요청);
     }
 
     @Test
     void 최대치_이름_길이를_초과하는_폴더를_생성하는_경우_예외를_반환한다() {
         // given
-        var url = "/memo-folders";
-        var request = new SaveMemoFolderRequest("회사생활은재미없겠지만해야겠지👔👔👔");
-        Member savedMember = memberRepository.save(MemberFixture.memberWithNickname("바로"));
-        setTokenDecrypt(savedMember);
+        var 요청_바디 = new SaveMemoFolderRequest("회사생활은재미없겠지만해야겠지👔👔👔");
+        var 토큰 = 로그인(OAuthMemberInfoFixture.은지());
 
         // when
-        var response = given(requestSpec).log().all()
-                .filter(document(DEFAULT_REST_DOCS_PATH,
-                        requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("인증 토큰")
-                        ),
-                        requestFields(
-                                fieldWithPath("folderName").description("폴더 이름")
-                        ),
-                        responseFields(
-                                fieldWithPath("errorCode").description("에러 코드"),
-                                fieldWithPath("errorMessage").description("에러 메시지")
-                        ))
-                ).header(HttpHeaders.AUTHORIZATION, SET_UP_ACCESS_TOKEN).body(request)
-                .when().post(url)
-                .then().log().all()
-                .extract();
+        var 응답 = 메모_폴더_생성_요청(토큰, 요청_바디);
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        응답값을_검증한다(응답, 잘못된_요청);
     }
 
     @Test
     void 메모_폴더를_불러온다() {
         // given
-        var url = "/memo-folders";
-        Member savedMember = memberRepository.save(MemberFixture.memberWithNickname("바로"));
-        setTokenDecrypt(savedMember);
-        memoFolderRepository.save(MemoFolder.defaultFolder(savedMember));
-        memoFolderRepository.save(MemoFolder.of(savedMember, "회사생활👔"));
+        Token 토큰 = 로그인(OAuthMemberInfoFixture.원진());
+        메모_폴더_생성_요청(토큰, new SaveMemoFolderRequest("회사생활👔"));
 
         // when
-        var response = given(requestSpec).log().all()
-                .filter(document(DEFAULT_REST_DOCS_PATH,
-                        requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("인증 토큰")
-                        ),
-                        responseFields(
-                                fieldWithPath("[].id").description("폴더 id"),
-                                fieldWithPath("[].name").description("폴더 이름")
-                        ))
-                ).header(HttpHeaders.AUTHORIZATION, SET_UP_ACCESS_TOKEN)
-                .when().get(url)
-                .then().log().all()
-                .extract();
+        var 응답 = 메모_폴더_불러오기_요청(토큰);
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        응답값을_검증한다(응답, 성공);
     }
 
-    void setTokenDecrypt(Member savedMember) {
-        given(tokenTranslator.decodeAccessToken(SET_UP_ACCESS_TOKEN)).willReturn(savedMember.getId());
-    }
-
-    void setTokenDecryptAsNotExistMember() {
-        given(tokenTranslator.decodeAccessToken(SET_UP_ACCESS_TOKEN)).willReturn(9999L);
+    void 멤버가_존재하지_않는다() {
+        doThrow(new MemberException(MemberExceptionType.NOT_EXIST_MEMBER)).when(memberRepository).getById(anyLong());
     }
 }

--- a/src/test/java/com/baro/memofolder/presentation/MemoFolderApiTest.java
+++ b/src/test/java/com/baro/memofolder/presentation/MemoFolderApiTest.java
@@ -12,7 +12,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.requestF
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 
 import com.baro.auth.application.TokenTranslator;
-import com.baro.common.RestApiDocumentationTest;
+import com.baro.common.RestApiTest;
 import com.baro.member.domain.Member;
 import com.baro.member.fixture.MemberFixture;
 import com.baro.memofolder.domain.MemoFolder;
@@ -27,7 +27,7 @@ import org.springframework.http.HttpStatus;
 
 @DisplayNameGeneration(ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
-class MemoFolderApiDocumentTest extends RestApiDocumentationTest {
+class MemoFolderApiTest extends RestApiTest {
 
     private static final String SET_UP_ACCESS_TOKEN = "accessToken";
 


### PR DESCRIPTION
## 관련된 이슈
<!-- 관련있는 이슈 번호(#000) 기입
merge를 기대하는 경우, close와 함께 기입-->

## 작업 사항
<!-- 구현한 내용에 대한 설명-->
- `@DisplayNameGeneration(ReplaceUnderscores.class)`와 `@SuppressWarnings("NonAsciiCharacters")` 어노테이션을 추가하였습니다.
- Mockito를 BDDMockito로 변경하였습니다.
- 클래스의 Document 네이밍을 제거하였습니다.
- 공통 인수테스트 스텝을 생성 후, 인수테스트로 리팩토링하였습니다.

## 기타
- `RestApiTest`에서 `OAuthInfoProvider`를 @SpyBean으로 선언하니 BDDMockito로는 동작하지않고 Mockito로만 동작하여.. 우선 아래와같이 Mockito를 사용하여 작업하였습니다. 
```java
  protected void OAuth_서버로부터_멤버_정보를_불러온다(OAuthMemberInfo memberInfo) {
    doReturn(memberInfo).when(oAuthInfoProvider).getMemberInfo(anyString(), anyString());
  }
```
- 각 ApiTest클래스에서 특정 로직에 대한 모킹이 필요한 경우 각 클래스 내부에서 수행하도록 구현해보았습니다.