### PR TITLE
feat: 끄적이는 메모 저장 api

### DIFF
--- a/src/main/java/com/baro/memo/application/MemoService.java
+++ b/src/main/java/com/baro/memo/application/MemoService.java
@@ -1,0 +1,27 @@
+package com.baro.memo.application;
+
+
+import com.baro.member.domain.Member;
+import com.baro.member.domain.MemberRepository;
+import com.baro.memo.application.dto.SaveTemporalMemoCommand;
+import com.baro.memo.application.dto.SaveTemporalMemoResult;
+import com.baro.memo.domain.TemporalMemo;
+import com.baro.memo.domain.TemporalMemoRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class MemoService {
+
+    private final MemberRepository memberRepository;
+    private final TemporalMemoRepository temporalMemoRepository;
+
+    public SaveTemporalMemoResult saveTemporalMemo(SaveTemporalMemoCommand command) {
+        Member member = memberRepository.getById(command.memberId());
+        TemporalMemo savedTemporalMemo = temporalMemoRepository.save(TemporalMemo.of(member, command.content()));
+        return SaveTemporalMemoResult.from(savedTemporalMemo);
+    }
+}

--- a/src/main/java/com/baro/memo/application/dto/SaveTemporalMemoCommand.java
+++ b/src/main/java/com/baro/memo/application/dto/SaveTemporalMemoCommand.java
@@ -1,0 +1,7 @@
+package com.baro.memo.application.dto;
+
+public record SaveTemporalMemoCommand(
+        Long memberId,
+        String content
+) {
+}

--- a/src/main/java/com/baro/memo/application/dto/SaveTemporalMemoResult.java
+++ b/src/main/java/com/baro/memo/application/dto/SaveTemporalMemoResult.java
@@ -1,0 +1,12 @@
+package com.baro.memo.application.dto;
+
+import com.baro.memo.domain.TemporalMemo;
+
+public record SaveTemporalMemoResult(
+        Long id
+) {
+
+    public static SaveTemporalMemoResult from(TemporalMemo temporalMemo) {
+        return new SaveTemporalMemoResult(temporalMemo.getId());
+    }
+}

--- a/src/main/java/com/baro/memo/domain/MemoContent.java
+++ b/src/main/java/com/baro/memo/domain/MemoContent.java
@@ -32,4 +32,8 @@ public class MemoContent {
     public static MemoContent from(String content) {
         return new MemoContent(content);
     }
+
+    public String value() {
+        return content;
+    }
 }

--- a/src/main/java/com/baro/memo/domain/MemoContent.java
+++ b/src/main/java/com/baro/memo/domain/MemoContent.java
@@ -1,5 +1,6 @@
 package com.baro.memo.domain;
 
+import com.baro.common.utils.EmojiUtils;
 import com.baro.memo.exception.MemoException;
 import com.baro.memo.exception.MemoExceptionType;
 import jakarta.persistence.Column;
@@ -24,7 +25,7 @@ public class MemoContent {
     }
 
     private void validate(String content) {
-        if (content.length() > MAX_CONTENT_SIZE) {
+        if (EmojiUtils.calculateLengthWithEmojis(content) > MAX_CONTENT_SIZE) {
             throw new MemoException(MemoExceptionType.OVER_MAX_SIZE_CONTENT);
         }
     }

--- a/src/main/java/com/baro/memo/domain/MemoContent.java
+++ b/src/main/java/com/baro/memo/domain/MemoContent.java
@@ -1,0 +1,35 @@
+package com.baro.memo.domain;
+
+import com.baro.memo.exception.MemoException;
+import com.baro.memo.exception.MemoExceptionType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Embeddable
+public class MemoContent {
+
+    private static final int MAX_CONTENT_SIZE = 500;
+
+    @Column(length = MAX_CONTENT_SIZE)
+    private String content;
+
+    private MemoContent(String content) {
+        validate(content);
+        this.content = content;
+    }
+
+    private void validate(String content) {
+        if (content.length() > MAX_CONTENT_SIZE) {
+            throw new MemoException(MemoExceptionType.OVER_MAX_SIZE_CONTENT);
+        }
+    }
+
+    public static MemoContent from(String content) {
+        return new MemoContent(content);
+    }
+}

--- a/src/main/java/com/baro/memo/domain/TemporalMemo.java
+++ b/src/main/java/com/baro/memo/domain/TemporalMemo.java
@@ -4,6 +4,7 @@ import com.baro.common.entity.BaseEntity;
 import com.baro.member.domain.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.ConstraintMode;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.ForeignKey;
 import jakarta.persistence.GeneratedValue;
@@ -30,8 +31,9 @@ public class TemporalMemo extends BaseEntity {
     @JoinColumn(name = "member_id", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private Member member;
 
-    @Column(length = 512, nullable = false)
-    private String content;
+    @Column(nullable = false)
+    @Embedded
+    private MemoContent content;
 
     @Column(length = 512)
     private String correctionContent;
@@ -40,7 +42,7 @@ public class TemporalMemo extends BaseEntity {
     @JoinColumn(name = "memo_id", nullable = true, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private Memo memo;
 
-    public TemporalMemo(Long id, Member member, String content, String correctionContent, Memo memo) {
+    public TemporalMemo(Long id, Member member, MemoContent content, String correctionContent, Memo memo) {
         this.id = id;
         this.member = member;
         this.content = content;
@@ -48,11 +50,11 @@ public class TemporalMemo extends BaseEntity {
         this.memo = memo;
     }
 
-    public TemporalMemo(Member member, String content, String correctionContent, Memo memo) {
+    public TemporalMemo(Member member, MemoContent content, String correctionContent, Memo memo) {
         this(null, member, content, correctionContent, memo);
     }
 
     public static TemporalMemo of(Member member, String content) {
-        return new TemporalMemo(member, content, null, null);
+        return new TemporalMemo(member, MemoContent.from(content), null, null);
     }
 }

--- a/src/main/java/com/baro/memo/domain/TemporalMemo.java
+++ b/src/main/java/com/baro/memo/domain/TemporalMemo.java
@@ -39,4 +39,20 @@ public class TemporalMemo extends BaseEntity {
     @OneToOne
     @JoinColumn(name = "memo_id", nullable = true, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private Memo memo;
+
+    public TemporalMemo(Long id, Member member, String content, String correctionContent, Memo memo) {
+        this.id = id;
+        this.member = member;
+        this.content = content;
+        this.correctionContent = correctionContent;
+        this.memo = memo;
+    }
+
+    public TemporalMemo(Member member, String content, String correctionContent, Memo memo) {
+        this(null, member, content, correctionContent, memo);
+    }
+
+    public static TemporalMemo of(Member member, String content) {
+        return new TemporalMemo(member, content, null, null);
+    }
 }

--- a/src/main/java/com/baro/memo/domain/TemporalMemo.java
+++ b/src/main/java/com/baro/memo/domain/TemporalMemo.java
@@ -11,13 +11,12 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class TemporalMemo extends BaseEntity {
@@ -33,4 +32,11 @@ public class TemporalMemo extends BaseEntity {
 
     @Column(length = 512, nullable = false)
     private String content;
+
+    @Column(length = 512)
+    private String correctionContent;
+
+    @OneToOne
+    @JoinColumn(name = "memo_id", nullable = true, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private Memo memo;
 }

--- a/src/main/java/com/baro/memo/domain/TemporalMemo.java
+++ b/src/main/java/com/baro/memo/domain/TemporalMemo.java
@@ -2,6 +2,7 @@ package com.baro.memo.domain;
 
 import com.baro.common.entity.BaseEntity;
 import com.baro.member.domain.Member;
+import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.Column;
 import jakarta.persistence.ConstraintMode;
 import jakarta.persistence.Embedded;
@@ -31,18 +32,19 @@ public class TemporalMemo extends BaseEntity {
     @JoinColumn(name = "member_id", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private Member member;
 
-    @Column(nullable = false)
     @Embedded
+    @AttributeOverride(name = "content", column = @Column(name = "content", nullable = false))
     private MemoContent content;
 
-    @Column(length = 512)
-    private String correctionContent;
+    @Embedded
+    @AttributeOverride(name = "content", column = @Column(name = "correction_content"))
+    private MemoContent correctionContent;
 
     @OneToOne
     @JoinColumn(name = "memo_id", nullable = true, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private Memo memo;
 
-    public TemporalMemo(Long id, Member member, MemoContent content, String correctionContent, Memo memo) {
+    public TemporalMemo(Long id, Member member, MemoContent content, MemoContent correctionContent, Memo memo) {
         this.id = id;
         this.member = member;
         this.content = content;
@@ -50,7 +52,7 @@ public class TemporalMemo extends BaseEntity {
         this.memo = memo;
     }
 
-    public TemporalMemo(Member member, MemoContent content, String correctionContent, Memo memo) {
+    public TemporalMemo(Member member, MemoContent content, MemoContent correctionContent, Memo memo) {
         this(null, member, content, correctionContent, memo);
     }
 

--- a/src/main/java/com/baro/memo/domain/TemporalMemoRepository.java
+++ b/src/main/java/com/baro/memo/domain/TemporalMemoRepository.java
@@ -1,0 +1,10 @@
+package com.baro.memo.domain;
+
+import java.util.List;
+
+public interface TemporalMemoRepository {
+
+    TemporalMemo save(TemporalMemo temporalMemo);
+
+    List<TemporalMemo> findAll();
+}

--- a/src/main/java/com/baro/memo/exception/MemoException.java
+++ b/src/main/java/com/baro/memo/exception/MemoException.java
@@ -1,0 +1,16 @@
+package com.baro.memo.exception;
+
+import com.baro.common.exception.RequestException;
+import com.baro.common.exception.RequestExceptionType;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class MemoException extends RequestException {
+
+    private final MemoExceptionType exceptionType;
+
+    @Override
+    public RequestExceptionType exceptionType() {
+        return exceptionType;
+    }
+}

--- a/src/main/java/com/baro/memo/exception/MemoExceptionType.java
+++ b/src/main/java/com/baro/memo/exception/MemoExceptionType.java
@@ -1,0 +1,31 @@
+package com.baro.memo.exception;
+
+import com.baro.common.exception.RequestExceptionType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum MemoExceptionType implements RequestExceptionType {
+
+    OVER_MAX_SIZE_CONTENT("MO01", "메모의 최대 길이는 500자입니다.", HttpStatus.BAD_REQUEST),
+    ;
+
+    private final String errorCode;
+    private final String errorMessage;
+    private final HttpStatus httpStatus;
+
+    @Override
+    public String errorCode() {
+        return errorCode;
+    }
+
+    @Override
+    public String errorMessage() {
+        return errorMessage;
+    }
+
+    @Override
+    public HttpStatus httpStatus() {
+        return httpStatus;
+    }
+}

--- a/src/main/java/com/baro/memo/infrastructure/TemporalMemoJpaRepository.java
+++ b/src/main/java/com/baro/memo/infrastructure/TemporalMemoJpaRepository.java
@@ -1,0 +1,7 @@
+package com.baro.memo.infrastructure;
+
+import com.baro.memo.domain.TemporalMemo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TemporalMemoJpaRepository extends JpaRepository<TemporalMemo, Long> {
+}

--- a/src/main/java/com/baro/memo/infrastructure/TemporalMemoRepositoryImpl.java
+++ b/src/main/java/com/baro/memo/infrastructure/TemporalMemoRepositoryImpl.java
@@ -13,7 +13,7 @@ public class TemporalMemoRepositoryImpl implements TemporalMemoRepository {
     private final TemporalMemoJpaRepository temporalMemoJpaRepository;
 
     @Override
-    public TemporalMemo save(final TemporalMemo temporalMemo) {
+    public TemporalMemo save(TemporalMemo temporalMemo) {
         return temporalMemoJpaRepository.save(temporalMemo);
     }
 

--- a/src/main/java/com/baro/memo/infrastructure/TemporalMemoRepositoryImpl.java
+++ b/src/main/java/com/baro/memo/infrastructure/TemporalMemoRepositoryImpl.java
@@ -1,0 +1,24 @@
+package com.baro.memo.infrastructure;
+
+import com.baro.memo.domain.TemporalMemo;
+import com.baro.memo.domain.TemporalMemoRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class TemporalMemoRepositoryImpl implements TemporalMemoRepository {
+
+    private final TemporalMemoJpaRepository temporalMemoJpaRepository;
+
+    @Override
+    public TemporalMemo save(final TemporalMemo temporalMemo) {
+        return temporalMemoJpaRepository.save(temporalMemo);
+    }
+
+    @Override
+    public List<TemporalMemo> findAll() {
+        return temporalMemoJpaRepository.findAll();
+    }
+}

--- a/src/main/java/com/baro/memo/presentation/MemoController.java
+++ b/src/main/java/com/baro/memo/presentation/MemoController.java
@@ -23,7 +23,7 @@ public class MemoController {
     private final MemoService memoService;
 
     @PostMapping("/temporal")
-    public ResponseEntity<Void> saveMemo(AuthMember authMember, @RequestBody SaveTemporalMemoRequest request) {
+    public ResponseEntity<Void> saveTemporalMemo(AuthMember authMember, @RequestBody SaveTemporalMemoRequest request) {
         SaveTemporalMemoCommand command = new SaveTemporalMemoCommand(authMember.id(), request.content());
         SaveTemporalMemoResult result = memoService.saveTemporalMemo(command);
 

--- a/src/main/java/com/baro/memo/presentation/MemoController.java
+++ b/src/main/java/com/baro/memo/presentation/MemoController.java
@@ -1,0 +1,36 @@
+package com.baro.memo.presentation;
+
+
+import com.baro.auth.domain.AuthMember;
+import com.baro.memo.application.MemoService;
+import com.baro.memo.application.dto.SaveTemporalMemoCommand;
+import com.baro.memo.application.dto.SaveTemporalMemoResult;
+import com.baro.memo.presentation.dto.SaveTemporalMemoRequest;
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+@RequiredArgsConstructor
+@RequestMapping("/memos")
+@RestController
+public class MemoController {
+
+    private final MemoService memoService;
+
+    @PostMapping("/temporal")
+    public ResponseEntity<Void> saveMemo(AuthMember authMember, @RequestBody SaveTemporalMemoRequest request) {
+        SaveTemporalMemoCommand command = new SaveTemporalMemoCommand(authMember.id(), request.content());
+        SaveTemporalMemoResult result = memoService.saveTemporalMemo(command);
+
+        URI location = ServletUriComponentsBuilder.fromCurrentRequest()
+                .path("/{id}")
+                .buildAndExpand(result.id())
+                .toUri();
+        return ResponseEntity.created(location).build();
+    }
+}

--- a/src/main/java/com/baro/memo/presentation/dto/SaveTemporalMemoRequest.java
+++ b/src/main/java/com/baro/memo/presentation/dto/SaveTemporalMemoRequest.java
@@ -1,0 +1,6 @@
+package com.baro.memo.presentation.dto;
+
+public record SaveTemporalMemoRequest(
+        String content
+) {
+}

--- a/src/test/java/com/baro/common/acceptance/memo/MemoAcceptanceSteps.java
+++ b/src/test/java/com/baro/common/acceptance/memo/MemoAcceptanceSteps.java
@@ -1,0 +1,57 @@
+package com.baro.common.acceptance.memo;
+
+import static com.baro.common.RestApiTest.DEFAULT_REST_DOCS_PATH;
+import static com.baro.common.RestApiTest.requestSpec;
+import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.document;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+
+import com.baro.auth.domain.Token;
+import com.baro.memo.presentation.dto.SaveTemporalMemoRequest;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+public class MemoAcceptanceSteps {
+
+    public static ExtractableResponse<Response> 끄적이는메모_생성_요청(Token 토큰, SaveTemporalMemoRequest 바디) {
+        return RestAssured.given(requestSpec).log().all()
+                .filter(document(DEFAULT_REST_DOCS_PATH,
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("인증 토큰")
+                        ),
+                        responseHeaders(
+                                headerWithName(HttpHeaders.LOCATION).description("생성된 끄적이는 메모 경로")
+                        ),
+                        requestFields(
+                                fieldWithPath("content").description("끄적이는 메모 내용")
+                        ))
+                ).contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + 토큰.accessToken()).body(바디)
+                .when().post("/memos/temporal")
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 잘못된_끄적이는_메모_생성_요청(Token 토큰, SaveTemporalMemoRequest 바디) {
+        return RestAssured.given(requestSpec).log().all()
+                .filter(document(DEFAULT_REST_DOCS_PATH,
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("인증 토큰")
+                        ),
+                        responseFields(
+                                fieldWithPath("errorCode").description("에러 코드"),
+                                fieldWithPath("errorMessage").description("에러 메시지")
+                        ))
+                ).header(HttpHeaders.AUTHORIZATION, "Bearer " + 토큰.accessToken()).body(바디)
+                .when().post("/memos/temporal")
+                .then().log().all()
+                .extract();
+    }
+}

--- a/src/test/java/com/baro/memo/application/MemoServiceTest.java
+++ b/src/test/java/com/baro/memo/application/MemoServiceTest.java
@@ -43,6 +43,6 @@ class MemoServiceTest {
         // then
         List<TemporalMemo> all = temporalMemoRepository.findAll();
         assertThat(all).hasSize(1);
-        assertThat(all.get(0).getContent()).isEqualTo(content);
+        assertThat(all.get(0).getContent().value()).isEqualTo(content);
     }
 }

--- a/src/test/java/com/baro/memo/application/MemoServiceTest.java
+++ b/src/test/java/com/baro/memo/application/MemoServiceTest.java
@@ -1,0 +1,48 @@
+package com.baro.memo.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.baro.member.domain.MemberRepository;
+import com.baro.member.fake.FakeMemberRepository;
+import com.baro.member.fixture.MemberFixture;
+import com.baro.memo.application.dto.SaveTemporalMemoCommand;
+import com.baro.memo.domain.TemporalMemo;
+import com.baro.memo.domain.TemporalMemoRepository;
+import com.baro.memo.fake.FakeTemporalMemoRepository;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class MemoServiceTest {
+
+    private MemoService memoService;
+    private MemberRepository memberRepository;
+    private TemporalMemoRepository temporalMemoRepository;
+
+    @BeforeEach
+    void setUp() {
+        memberRepository = new FakeMemberRepository();
+        temporalMemoRepository = new FakeTemporalMemoRepository();
+        memoService = new MemoService(memberRepository, temporalMemoRepository);
+    }
+
+    @Test
+    void 끄적이는_메모_저장() {
+        // given
+        Long memberId = memberRepository.save(MemberFixture.memberWithNickname("nickname1")).getId();
+        String content = "testContent";
+        SaveTemporalMemoCommand command = new SaveTemporalMemoCommand(memberId, content);
+
+        // when
+        memoService.saveTemporalMemo(command);
+
+        // then
+        List<TemporalMemo> all = temporalMemoRepository.findAll();
+        assertThat(all).hasSize(1);
+        assertThat(all.get(0).getContent()).isEqualTo(content);
+    }
+}

--- a/src/test/java/com/baro/memo/domain/MemoContentTest.java
+++ b/src/test/java/com/baro/memo/domain/MemoContentTest.java
@@ -1,0 +1,37 @@
+package com.baro.memo.domain;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.baro.memo.exception.MemoException;
+import com.baro.memo.exception.MemoExceptionType;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class MemoContentTest {
+
+    @Test
+    void 메모_내용_생성() {
+        // given
+        String content = "끄적이는 메모 컨텐츠";
+
+        // when & then
+        assertThatCode(() -> MemoContent.from(content))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void 메모_내용_생성_최대_길이_초과() {
+        // given
+        String content = "끄적이는 메모 컨텐츠".repeat(500);
+
+        // when & then
+        assertThatThrownBy(() -> MemoContent.from(content))
+                .isInstanceOf(MemoException.class)
+                .extracting("exceptionType")
+                .isEqualTo(MemoExceptionType.OVER_MAX_SIZE_CONTENT);
+    }
+}

--- a/src/test/java/com/baro/memo/fake/FakeTemporalMemoRepository.java
+++ b/src/test/java/com/baro/memo/fake/FakeTemporalMemoRepository.java
@@ -1,0 +1,37 @@
+package com.baro.memo.fake;
+
+import com.baro.memo.domain.TemporalMemo;
+import com.baro.memo.domain.TemporalMemoRepository;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class FakeTemporalMemoRepository implements TemporalMemoRepository {
+
+    private final AtomicLong id = new AtomicLong(1);
+    private final Map<Long, TemporalMemo> temporalMemos = new ConcurrentHashMap<>();
+
+    @Override
+    public TemporalMemo save(TemporalMemo temporalMemo) {
+        if (Objects.isNull(temporalMemo.getId())) {
+            TemporalMemo newMemoFolder = new TemporalMemo(
+                    id.getAndIncrement(),
+                    temporalMemo.getMember(),
+                    temporalMemo.getContent(),
+                    temporalMemo.getCorrectionContent(),
+                    temporalMemo.getMemo()
+            );
+            temporalMemos.put(newMemoFolder.getId(), newMemoFolder);
+            return newMemoFolder;
+        }
+        temporalMemos.put(temporalMemo.getId(), temporalMemo);
+        return temporalMemo;
+    }
+
+    @Override
+    public List<TemporalMemo> findAll() {
+        return List.copyOf(temporalMemos.values());
+    }
+}

--- a/src/test/java/com/baro/memo/presentation/MemoApiTest.java
+++ b/src/test/java/com/baro/memo/presentation/MemoApiTest.java
@@ -8,6 +8,7 @@ import static org.springframework.restdocs.headers.HeaderDocumentation.requestHe
 import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 
 import com.baro.auth.application.TokenTranslator;
 import com.baro.common.RestApiDocumentationTest;
@@ -16,11 +17,14 @@ import com.baro.member.fixture.MemberFixture;
 import com.baro.memo.presentation.dto.SaveTemporalMemoRequest;
 import io.restassured.RestAssured;
 import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 
+@DisplayNameGeneration(ReplaceUnderscores.class)
 public class MemoApiTest extends RestApiDocumentationTest {
 
     private static final String SET_UP_ACCESS_TOKEN = "accessToken";
@@ -57,6 +61,33 @@ public class MemoApiTest extends RestApiDocumentationTest {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
         String location = new String(response.header("Location").getBytes(StandardCharsets.UTF_8));
         assertThat(location).isNotNull();
+    }
+
+    @Test
+    void create_temporal_memo_over_max_size_content() {
+        // given
+        var url = "/memos/temporal";
+        var request = new SaveTemporalMemoRequest("끄적이는 메모 컨텐츠".repeat(500));
+        Member savedMember = memberRepository.save(MemberFixture.memberWithNickname("바로")); // TODO: 인수테스트 steps로 변경
+        setTokenDecrypt(savedMember);
+
+        // when
+        var response = RestAssured.given(requestSpec).log().all()
+                .filter(document(DEFAULT_REST_DOCS_PATH,
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("인증 토큰")
+                        ),
+                        responseFields(
+                                fieldWithPath("errorCode").description("에러 코드"),
+                                fieldWithPath("errorMessage").description("에러 메시지")
+                        ))
+                ).header(HttpHeaders.AUTHORIZATION, SET_UP_ACCESS_TOKEN).body(request)
+                .when().post(url)
+                .then().log().all()
+                .extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
     }
 
     void setTokenDecrypt(Member savedMember) {

--- a/src/test/java/com/baro/memo/presentation/MemoApiTest.java
+++ b/src/test/java/com/baro/memo/presentation/MemoApiTest.java
@@ -37,7 +37,7 @@ public class MemoApiTest extends RestApiTest {
     }
 
     @Test
-    void create_temporal_memo_over_max_size_content() {
+    void 최대치_이름_길이를_초과하는_끄적이는_메모_생성하는_경우_예외를_반환한다() {
         // given
         var 토큰 = 로그인(태연());
         var 요청_바디 = OVER_SIZE_MEMO_CONTENT;

--- a/src/test/java/com/baro/memo/presentation/MemoApiTest.java
+++ b/src/test/java/com/baro/memo/presentation/MemoApiTest.java
@@ -1,96 +1,51 @@
 package com.baro.memo.presentation;
 
-import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.document;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
-import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
-import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
-import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static com.baro.auth.fixture.OAuthMemberInfoFixture.태연;
+import static com.baro.common.acceptance.AcceptanceSteps.생성됨;
+import static com.baro.common.acceptance.AcceptanceSteps.응답값을_검증한다;
+import static com.baro.common.acceptance.AcceptanceSteps.응답의_Location_헤더가_존재한다;
+import static com.baro.common.acceptance.AcceptanceSteps.잘못된_요청;
+import static com.baro.common.acceptance.memo.MemoAcceptanceSteps.끄적이는메모_생성_요청;
+import static com.baro.common.acceptance.memo.MemoAcceptanceSteps.잘못된_끄적이는_메모_생성_요청;
 
-import com.baro.auth.application.TokenTranslator;
-import com.baro.common.RestApiDocumentationTest;
-import com.baro.member.domain.Member;
-import com.baro.member.fixture.MemberFixture;
+import com.baro.common.RestApiTest;
 import com.baro.memo.presentation.dto.SaveTemporalMemoRequest;
-import io.restassured.RestAssured;
-import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
 
 @DisplayNameGeneration(ReplaceUnderscores.class)
-public class MemoApiTest extends RestApiDocumentationTest {
+@SuppressWarnings("NonAsciiCharacters")
+public class MemoApiTest extends RestApiTest {
 
-    private static final String SET_UP_ACCESS_TOKEN = "accessToken";
-
-    @MockBean
-    TokenTranslator tokenTranslator;
+    private static final SaveTemporalMemoRequest 끄적이는_메모_컨텐츠 = new SaveTemporalMemoRequest("끄적이는 메모 컨텐츠");
+    private static final SaveTemporalMemoRequest OVER_SIZE_MEMO_CONTENT = new SaveTemporalMemoRequest(
+            "끄적이는 메모 컨텐츠".repeat(500));
 
     @Test
-    void create_temporal_memo() {
+    void 끄적이는_메모를_작성_한다() {
         // given
-        var url = "/memos/temporal";
-        var request = new SaveTemporalMemoRequest("끄적이는 메모 컨텐츠");
-        Member savedMember = memberRepository.save(MemberFixture.memberWithNickname("바로")); // TODO: 인수테스트 steps로 변경
-        setTokenDecrypt(savedMember);
+        var 토큰 = 로그인(태연());
+        var 요청_바디 = 끄적이는_메모_컨텐츠;
 
         // when
-        var response = RestAssured.given(requestSpec).log().all()
-                .filter(document(DEFAULT_REST_DOCS_PATH,
-                        requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("인증 토큰")
-                        ),
-                        responseHeaders(
-                                headerWithName(HttpHeaders.LOCATION).description("생성된 끄적이는 메모 경로")
-                        ),
-                        requestFields(
-                                fieldWithPath("content").description("끄적이는 메모 내용")
-                        ))
-                ).header(HttpHeaders.AUTHORIZATION, SET_UP_ACCESS_TOKEN).body(request)
-                .when().post(url)
-                .then().log().all()
-                .extract();
+        var 응답 = 끄적이는메모_생성_요청(토큰, 요청_바디);
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
-        String location = new String(response.header("Location").getBytes(StandardCharsets.UTF_8));
-        assertThat(location).isNotNull();
+        응답값을_검증한다(응답, 생성됨);
+        응답의_Location_헤더가_존재한다(응답);
     }
 
     @Test
     void create_temporal_memo_over_max_size_content() {
         // given
-        var url = "/memos/temporal";
-        var request = new SaveTemporalMemoRequest("끄적이는 메모 컨텐츠".repeat(500));
-        Member savedMember = memberRepository.save(MemberFixture.memberWithNickname("바로")); // TODO: 인수테스트 steps로 변경
-        setTokenDecrypt(savedMember);
+        var 토큰 = 로그인(태연());
+        var 요청_바디 = OVER_SIZE_MEMO_CONTENT;
 
         // when
-        var response = RestAssured.given(requestSpec).log().all()
-                .filter(document(DEFAULT_REST_DOCS_PATH,
-                        requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("인증 토큰")
-                        ),
-                        responseFields(
-                                fieldWithPath("errorCode").description("에러 코드"),
-                                fieldWithPath("errorMessage").description("에러 메시지")
-                        ))
-                ).header(HttpHeaders.AUTHORIZATION, SET_UP_ACCESS_TOKEN).body(request)
-                .when().post(url)
-                .then().log().all()
-                .extract();
+        var 응답 = 잘못된_끄적이는_메모_생성_요청(토큰, 요청_바디);
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
-    }
-
-    void setTokenDecrypt(Member savedMember) {
-        given(tokenTranslator.decodeAccessToken(SET_UP_ACCESS_TOKEN)).willReturn(savedMember.getId());
+        응답값을_검증한다(응답, 잘못된_요청);
     }
 }

--- a/src/test/java/com/baro/memo/presentation/MemoApiTest.java
+++ b/src/test/java/com/baro/memo/presentation/MemoApiTest.java
@@ -1,0 +1,65 @@
+package com.baro.memo.presentation;
+
+import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.document;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+
+import com.baro.auth.application.TokenTranslator;
+import com.baro.common.RestApiDocumentationTest;
+import com.baro.member.domain.Member;
+import com.baro.member.fixture.MemberFixture;
+import com.baro.memo.presentation.dto.SaveTemporalMemoRequest;
+import io.restassured.RestAssured;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+
+public class MemoApiTest extends RestApiDocumentationTest {
+
+    private static final String SET_UP_ACCESS_TOKEN = "accessToken";
+
+    @MockBean
+    TokenTranslator tokenTranslator;
+
+    @Test
+    void create_temporal_memo() {
+        // given
+        var url = "/memos/temporal";
+        var request = new SaveTemporalMemoRequest("끄적이는 메모 컨텐츠");
+        Member savedMember = memberRepository.save(MemberFixture.memberWithNickname("바로")); // TODO: 인수테스트 steps로 변경
+        setTokenDecrypt(savedMember);
+
+        // when
+        var response = RestAssured.given(requestSpec).log().all()
+                .filter(document(DEFAULT_REST_DOCS_PATH,
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("인증 토큰")
+                        ),
+                        responseHeaders(
+                                headerWithName(HttpHeaders.LOCATION).description("생성된 끄적이는 메모 경로")
+                        ),
+                        requestFields(
+                                fieldWithPath("content").description("끄적이는 메모 내용")
+                        ))
+                ).header(HttpHeaders.AUTHORIZATION, SET_UP_ACCESS_TOKEN).body(request)
+                .when().post(url)
+                .then().log().all()
+                .extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+        String location = new String(response.header("Location").getBytes(StandardCharsets.UTF_8));
+        assertThat(location).isNotNull();
+    }
+
+    void setTokenDecrypt(Member savedMember) {
+        given(tokenTranslator.decodeAccessToken(SET_UP_ACCESS_TOKEN)).willReturn(savedMember.getId());
+    }
+}


### PR DESCRIPTION
## 관련된 이슈
BAR-192

## 작업 사항
- 끄적이는 메모 생성 API 추가
- 맞춤법 검사 결과를 저장하는 correction_content 컬럼을 추가했습니다.
- memo_id를 추가했습니다. 끄적이는 메모의 저장 유무, 중복 저장 방지, 메모 삭제시 저장 유무 변경에 대응하기 위함입니다.
변경 DDL https://github.com/shinyubin989/sub-module/commit/cefa3c99fd2baf6a0936c3f2e4f01162e7f14f53
