### PR TITLE
feat: 템플릿 불러오기

### DIFF
--- a/src/main/java/com/baro/common/entity/BaseEntity.java
+++ b/src/main/java/com/baro/common/entity/BaseEntity.java
@@ -14,8 +14,8 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 public class BaseEntity {
 
     @CreatedDate
-    private LocalDateTime createdAt;
+    protected LocalDateTime createdAt;
 
     @LastModifiedDate
-    private LocalDateTime updatedAt;
+    protected LocalDateTime updatedAt;
 }

--- a/src/main/java/com/baro/template/application/TemplateService.java
+++ b/src/main/java/com/baro/template/application/TemplateService.java
@@ -1,0 +1,29 @@
+package com.baro.template.application;
+
+import com.baro.template.application.dto.FindTemplateQuery;
+import com.baro.template.application.dto.FindTemplateResult;
+import com.baro.template.domain.TemplateRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class TemplateService {
+
+    private final TemplateRepository repository;
+
+    public List<FindTemplateResult> findTemplates(FindTemplateQuery query) {
+        int pageSize = repository.count();
+        if (pageSize < 1) {
+            return List.of();
+        }
+
+        PageRequest pageRequest = PageRequest.of(0, pageSize, query.sort());
+        return repository.findAllByCategory(query.category(), pageRequest)
+                .stream().map(FindTemplateResult::from).toList();
+    }
+}

--- a/src/main/java/com/baro/template/application/TemplateService.java
+++ b/src/main/java/com/baro/template/application/TemplateService.java
@@ -3,9 +3,9 @@ package com.baro.template.application;
 import com.baro.template.application.dto.FindTemplateQuery;
 import com.baro.template.application.dto.FindTemplateResult;
 import com.baro.template.domain.TemplateRepository;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,14 +17,9 @@ public class TemplateService {
     private final TemplateRepository repository;
 
     @Transactional(readOnly = true)
-    public List<FindTemplateResult> findTemplates(FindTemplateQuery query) {
-        int pageSize = repository.count();
-        if (pageSize < 1) {
-            return List.of();
-        }
+    public Slice<FindTemplateResult> findTemplates(FindTemplateQuery query) {
+        PageRequest pageRequest = PageRequest.of(0, Integer.MAX_VALUE - 1, query.sort());
 
-        PageRequest pageRequest = PageRequest.of(0, pageSize, query.sort());
-        return repository.findAllByCategory(query.templateCategory(), pageRequest)
-                .stream().map(FindTemplateResult::from).toList();
+        return repository.findAllByCategory(query.templateCategory(), pageRequest).map(FindTemplateResult::from);
     }
 }

--- a/src/main/java/com/baro/template/application/TemplateService.java
+++ b/src/main/java/com/baro/template/application/TemplateService.java
@@ -16,6 +16,7 @@ public class TemplateService {
 
     private final TemplateRepository repository;
 
+    @Transactional(readOnly = true)
     public List<FindTemplateResult> findTemplates(FindTemplateQuery query) {
         int pageSize = repository.count();
         if (pageSize < 1) {
@@ -23,7 +24,7 @@ public class TemplateService {
         }
 
         PageRequest pageRequest = PageRequest.of(0, pageSize, query.sort());
-        return repository.findAllByCategory(query.category(), pageRequest)
+        return repository.findAllByCategory(query.templateCategory(), pageRequest)
                 .stream().map(FindTemplateResult::from).toList();
     }
 }

--- a/src/main/java/com/baro/template/application/dto/FindTemplateQuery.java
+++ b/src/main/java/com/baro/template/application/dto/FindTemplateQuery.java
@@ -1,0 +1,10 @@
+package com.baro.template.application.dto;
+
+import com.baro.template.domain.Category;
+import org.springframework.data.domain.Sort;
+
+public record FindTemplateQuery(
+        Category category,
+        Sort sort
+) {
+}

--- a/src/main/java/com/baro/template/application/dto/FindTemplateQuery.java
+++ b/src/main/java/com/baro/template/application/dto/FindTemplateQuery.java
@@ -1,10 +1,10 @@
 package com.baro.template.application.dto;
 
-import com.baro.template.domain.Category;
+import com.baro.template.domain.TemplateCategory;
 import org.springframework.data.domain.Sort;
 
 public record FindTemplateQuery(
-        Category category,
+        TemplateCategory templateCategory,
         Sort sort
 ) {
 }

--- a/src/main/java/com/baro/template/application/dto/FindTemplateResult.java
+++ b/src/main/java/com/baro/template/application/dto/FindTemplateResult.java
@@ -14,7 +14,7 @@ public record FindTemplateResult(
     public static FindTemplateResult from(Template template) {
         return new FindTemplateResult(
                 template.getId(),
-                template.getTemplateCategory().name().toLowerCase(),
+                template.getCategory().name().toLowerCase(),
                 template.getSubCategory(),
                 template.getContent(),
                 template.getSavedCount(),

--- a/src/main/java/com/baro/template/application/dto/FindTemplateResult.java
+++ b/src/main/java/com/baro/template/application/dto/FindTemplateResult.java
@@ -1,0 +1,24 @@
+package com.baro.template.application.dto;
+
+import com.baro.template.domain.Template;
+
+public record FindTemplateResult(
+        Long templateId,
+        String category,
+        String subCategory,
+        String content,
+        int savedCount,
+        int copiedCount
+) {
+
+    public static FindTemplateResult from(Template template) {
+        return new FindTemplateResult(
+                template.getId(),
+                template.getCategory().name().toLowerCase(),
+                template.getSubCategory(),
+                template.getContent(),
+                template.getSavedCount(),
+                template.getCopiedCount()
+        );
+    }
+}

--- a/src/main/java/com/baro/template/application/dto/FindTemplateResult.java
+++ b/src/main/java/com/baro/template/application/dto/FindTemplateResult.java
@@ -14,7 +14,7 @@ public record FindTemplateResult(
     public static FindTemplateResult from(Template template) {
         return new FindTemplateResult(
                 template.getId(),
-                template.getCategory().name().toLowerCase(),
+                template.getTemplateCategory().name().toLowerCase(),
                 template.getSubCategory(),
                 template.getContent(),
                 template.getSavedCount(),

--- a/src/main/java/com/baro/template/domain/Category.java
+++ b/src/main/java/com/baro/template/domain/Category.java
@@ -1,0 +1,28 @@
+package com.baro.template.domain;
+
+import com.baro.template.exception.TemplateException;
+import com.baro.template.exception.TemplateExceptionType;
+import java.util.Arrays;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum Category {
+
+    ASK,
+    REPORT,
+    CELEBRATE,
+    THANK,
+    COMFORT,
+    REGARD,
+    ETC,
+    ;
+
+    public static Category getCategory(String name) {
+        return Arrays.stream(Category.values())
+                .filter(category -> category.name().equalsIgnoreCase(name))
+                .findFirst()
+                .orElseThrow(() -> new TemplateException(TemplateExceptionType.INVALID_CATEGORY));
+    }
+}

--- a/src/main/java/com/baro/template/domain/Template.java
+++ b/src/main/java/com/baro/template/domain/Template.java
@@ -47,14 +47,14 @@ public class Template extends BaseEntity {
     /**
      * 테스트용 팩토리메서드
      */
-    public static Template instanceForTest(TemplateCategory templateCategory, String subCategory, String content,
-                                           int copiedCount,
-                                           int savedCount) {
-        return new Template(templateCategory, subCategory, content, copiedCount, savedCount);
+    public static Template instanceForTest(Long id, TemplateCategory templateCategory, String subCategory,
+                                           String content, int copiedCount, int savedCount) {
+        return new Template(id, templateCategory, subCategory, content, copiedCount, savedCount);
     }
 
-    private Template(TemplateCategory templateCategory, String subCategory, String content, int copiedCount,
+    private Template(Long id, TemplateCategory templateCategory, String subCategory, String content, int copiedCount,
                      int savedCount) {
+        this.id = id;
         this.templateCategory = templateCategory;
         this.subCategory = subCategory;
         this.content = content;

--- a/src/main/java/com/baro/template/domain/Template.java
+++ b/src/main/java/com/baro/template/domain/Template.java
@@ -25,7 +25,7 @@ public class Template extends BaseEntity {
 
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
-    private TemplateCategory templateCategory;
+    private TemplateCategory category;
 
     private String subCategory;
 
@@ -36,8 +36,8 @@ public class Template extends BaseEntity {
 
     private int savedCount;
 
-    public Template(TemplateCategory templateCategory, String subCategory, String content) {
-        this.templateCategory = templateCategory;
+    public Template(TemplateCategory category, String subCategory, String content) {
+        this.category = category;
         this.subCategory = subCategory;
         this.content = content;
         this.copiedCount = 0;
@@ -47,15 +47,15 @@ public class Template extends BaseEntity {
     /**
      * 테스트용 팩토리메서드
      */
-    public static Template instanceForTest(Long id, TemplateCategory templateCategory, String subCategory,
+    public static Template instanceForTest(Long id, TemplateCategory category, String subCategory,
                                            String content, int copiedCount, int savedCount) {
-        return new Template(id, templateCategory, subCategory, content, copiedCount, savedCount);
+        return new Template(id, category, subCategory, content, copiedCount, savedCount);
     }
 
-    private Template(Long id, TemplateCategory templateCategory, String subCategory, String content, int copiedCount,
+    private Template(Long id, TemplateCategory category, String subCategory, String content, int copiedCount,
                      int savedCount) {
         this.id = id;
-        this.templateCategory = templateCategory;
+        this.category = category;
         this.subCategory = subCategory;
         this.content = content;
         this.copiedCount = copiedCount;

--- a/src/main/java/com/baro/template/domain/Template.java
+++ b/src/main/java/com/baro/template/domain/Template.java
@@ -36,7 +36,23 @@ public class Template extends BaseEntity {
 
     private int savedCount;
 
-    public Template(Category category, String subCategory, String content, int copiedCount, int savedCount) {
+    public Template(Category category, String subCategory, String content) {
+        this.category = category;
+        this.subCategory = subCategory;
+        this.content = content;
+        this.copiedCount = 0;
+        this.savedCount = 0;
+    }
+
+    /**
+     * 테스트용 팩토리메서드
+     */
+    public static Template instanceForTest(Category category, String subCategory, String content, int copiedCount,
+                                           int savedCount) {
+        return new Template(category, subCategory, content, copiedCount, savedCount);
+    }
+
+    private Template(Category category, String subCategory, String content, int copiedCount, int savedCount) {
         this.category = category;
         this.subCategory = subCategory;
         this.content = content;
@@ -44,13 +60,5 @@ public class Template extends BaseEntity {
         this.savedCount = savedCount;
         this.createdAt = LocalDateTime.now();
         this.updatedAt = LocalDateTime.now();
-    }
-
-    public Template(Category category, String subCategory, String content) {
-        this.category = category;
-        this.subCategory = subCategory;
-        this.content = content;
-        this.copiedCount = 0;
-        this.savedCount = 0;
     }
 }

--- a/src/main/java/com/baro/template/domain/Template.java
+++ b/src/main/java/com/baro/template/domain/Template.java
@@ -25,7 +25,7 @@ public class Template extends BaseEntity {
 
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
-    private Category category;
+    private TemplateCategory templateCategory;
 
     private String subCategory;
 
@@ -36,8 +36,8 @@ public class Template extends BaseEntity {
 
     private int savedCount;
 
-    public Template(Category category, String subCategory, String content) {
-        this.category = category;
+    public Template(TemplateCategory templateCategory, String subCategory, String content) {
+        this.templateCategory = templateCategory;
         this.subCategory = subCategory;
         this.content = content;
         this.copiedCount = 0;
@@ -47,13 +47,15 @@ public class Template extends BaseEntity {
     /**
      * 테스트용 팩토리메서드
      */
-    public static Template instanceForTest(Category category, String subCategory, String content, int copiedCount,
+    public static Template instanceForTest(TemplateCategory templateCategory, String subCategory, String content,
+                                           int copiedCount,
                                            int savedCount) {
-        return new Template(category, subCategory, content, copiedCount, savedCount);
+        return new Template(templateCategory, subCategory, content, copiedCount, savedCount);
     }
 
-    private Template(Category category, String subCategory, String content, int copiedCount, int savedCount) {
-        this.category = category;
+    private Template(TemplateCategory templateCategory, String subCategory, String content, int copiedCount,
+                     int savedCount) {
+        this.templateCategory = templateCategory;
         this.subCategory = subCategory;
         this.content = content;
         this.copiedCount = copiedCount;

--- a/src/main/java/com/baro/template/domain/Template.java
+++ b/src/main/java/com/baro/template/domain/Template.java
@@ -3,9 +3,12 @@ package com.baro.template.domain;
 import com.baro.common.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -21,7 +24,8 @@ public class Template extends BaseEntity {
     private Long id;
 
     @Column(nullable = false)
-    private String category;
+    @Enumerated(EnumType.STRING)
+    private Category category;
 
     private String subCategory;
 
@@ -31,4 +35,22 @@ public class Template extends BaseEntity {
     private int copiedCount;
 
     private int savedCount;
+
+    public Template(Category category, String subCategory, String content, int copiedCount, int savedCount) {
+        this.category = category;
+        this.subCategory = subCategory;
+        this.content = content;
+        this.copiedCount = copiedCount;
+        this.savedCount = savedCount;
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public Template(Category category, String subCategory, String content) {
+        this.category = category;
+        this.subCategory = subCategory;
+        this.content = content;
+        this.copiedCount = 0;
+        this.savedCount = 0;
+    }
 }

--- a/src/main/java/com/baro/template/domain/TemplateCategory.java
+++ b/src/main/java/com/baro/template/domain/TemplateCategory.java
@@ -8,7 +8,7 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @Getter
-public enum Category {
+public enum TemplateCategory {
 
     ASK,
     REPORT,
@@ -19,8 +19,8 @@ public enum Category {
     ETC,
     ;
 
-    public static Category getCategory(String name) {
-        return Arrays.stream(Category.values())
+    public static TemplateCategory getCategory(String name) {
+        return Arrays.stream(TemplateCategory.values())
                 .filter(category -> category.name().equalsIgnoreCase(name))
                 .findFirst()
                 .orElseThrow(() -> new TemplateException(TemplateExceptionType.INVALID_CATEGORY));

--- a/src/main/java/com/baro/template/domain/TemplateRepository.java
+++ b/src/main/java/com/baro/template/domain/TemplateRepository.java
@@ -8,6 +8,4 @@ public interface TemplateRepository {
     Slice<Template> findAllByCategory(TemplateCategory templateCategory, Pageable pageable);
 
     Template save(Template template);
-
-    int count();
 }

--- a/src/main/java/com/baro/template/domain/TemplateRepository.java
+++ b/src/main/java/com/baro/template/domain/TemplateRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.domain.Pageable;
 
 public interface TemplateRepository {
 
-    List<Template> findAllByCategory(Category category, Pageable pageable);
+    List<Template> findAllByCategory(TemplateCategory templateCategory, Pageable pageable);
 
     Template save(Template template);
 

--- a/src/main/java/com/baro/template/domain/TemplateRepository.java
+++ b/src/main/java/com/baro/template/domain/TemplateRepository.java
@@ -1,11 +1,11 @@
 package com.baro.template.domain;
 
-import java.util.List;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 
 public interface TemplateRepository {
 
-    List<Template> findAllByCategory(TemplateCategory templateCategory, Pageable pageable);
+    Slice<Template> findAllByCategory(TemplateCategory templateCategory, Pageable pageable);
 
     Template save(Template template);
 

--- a/src/main/java/com/baro/template/domain/TemplateRepository.java
+++ b/src/main/java/com/baro/template/domain/TemplateRepository.java
@@ -7,5 +7,7 @@ public interface TemplateRepository {
 
     List<Template> findAllByCategory(Category category, Pageable pageable);
 
+    Template save(Template template);
+
     int count();
 }

--- a/src/main/java/com/baro/template/domain/TemplateRepository.java
+++ b/src/main/java/com/baro/template/domain/TemplateRepository.java
@@ -1,0 +1,11 @@
+package com.baro.template.domain;
+
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+
+public interface TemplateRepository {
+
+    List<Template> findAllByCategory(Category category, Pageable pageable);
+
+    int count();
+}

--- a/src/main/java/com/baro/template/exception/SortException.java
+++ b/src/main/java/com/baro/template/exception/SortException.java
@@ -1,0 +1,16 @@
+package com.baro.template.exception;
+
+import com.baro.common.exception.RequestException;
+import com.baro.common.exception.RequestExceptionType;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class SortException extends RequestException {
+
+    private final SortExceptionType exceptionType;
+
+    @Override
+    public RequestExceptionType exceptionType() {
+        return exceptionType;
+    }
+}

--- a/src/main/java/com/baro/template/exception/SortExceptionType.java
+++ b/src/main/java/com/baro/template/exception/SortExceptionType.java
@@ -1,0 +1,30 @@
+package com.baro.template.exception;
+
+import com.baro.common.exception.RequestExceptionType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum SortExceptionType implements RequestExceptionType {
+
+    INVALID_SORT_TYPE("SO01", "유효하지 않은 정렬 타입입니다.", HttpStatus.BAD_REQUEST);
+
+    private final String errorCode;
+    private final String errorMessage;
+    private final HttpStatus httpStatus;
+
+    @Override
+    public String errorCode() {
+        return errorCode;
+    }
+
+    @Override
+    public String errorMessage() {
+        return errorMessage;
+    }
+
+    @Override
+    public HttpStatus httpStatus() {
+        return httpStatus;
+    }
+}

--- a/src/main/java/com/baro/template/exception/TemplateException.java
+++ b/src/main/java/com/baro/template/exception/TemplateException.java
@@ -1,0 +1,16 @@
+package com.baro.template.exception;
+
+import com.baro.common.exception.RequestException;
+import com.baro.common.exception.RequestExceptionType;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class TemplateException extends RequestException {
+
+    private final TemplateExceptionType exceptionType;
+
+    @Override
+    public RequestExceptionType exceptionType() {
+        return exceptionType;
+    }
+}

--- a/src/main/java/com/baro/template/exception/TemplateExceptionType.java
+++ b/src/main/java/com/baro/template/exception/TemplateExceptionType.java
@@ -1,0 +1,32 @@
+package com.baro.template.exception;
+
+import com.baro.common.exception.RequestExceptionType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum TemplateExceptionType implements RequestExceptionType {
+
+    INVALID_CATEGORY("TE01", "존재하지 않는 카테고리입니다.", HttpStatus.BAD_REQUEST),
+    EMPTY_TEMPLATE("TE02", "해당 카테고리에 템플릿이 존재하지 않습니다", HttpStatus.NO_CONTENT),
+    ;
+
+    private final String errorCode;
+    private final String errorMessage;
+    private final HttpStatus httpStatus;
+
+    @Override
+    public String errorCode() {
+        return errorCode;
+    }
+
+    @Override
+    public String errorMessage() {
+        return errorMessage;
+    }
+
+    @Override
+    public HttpStatus httpStatus() {
+        return httpStatus;
+    }
+}

--- a/src/main/java/com/baro/template/exception/TemplateExceptionType.java
+++ b/src/main/java/com/baro/template/exception/TemplateExceptionType.java
@@ -8,7 +8,6 @@ import org.springframework.http.HttpStatus;
 public enum TemplateExceptionType implements RequestExceptionType {
 
     INVALID_CATEGORY("TE01", "존재하지 않는 카테고리입니다.", HttpStatus.BAD_REQUEST),
-    EMPTY_TEMPLATE("TE02", "해당 카테고리에 템플릿이 존재하지 않습니다", HttpStatus.NO_CONTENT),
     ;
 
     private final String errorCode;

--- a/src/main/java/com/baro/template/infra/TemplateJpaRepository.java
+++ b/src/main/java/com/baro/template/infra/TemplateJpaRepository.java
@@ -2,11 +2,11 @@ package com.baro.template.infra;
 
 import com.baro.template.domain.Template;
 import com.baro.template.domain.TemplateCategory;
-import java.util.List;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TemplateJpaRepository extends JpaRepository<Template, Long> {
 
-    List<Template> findAllByCategory(TemplateCategory templateCategory, Pageable pageable);
+    Slice<Template> findAllByCategory(TemplateCategory templateCategory, Pageable pageable);
 }

--- a/src/main/java/com/baro/template/infra/TemplateJpaRepository.java
+++ b/src/main/java/com/baro/template/infra/TemplateJpaRepository.java
@@ -1,12 +1,12 @@
 package com.baro.template.infra;
 
-import com.baro.template.domain.Category;
 import com.baro.template.domain.Template;
+import com.baro.template.domain.TemplateCategory;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TemplateJpaRepository extends JpaRepository<Template, Long> {
 
-    List<Template> findAllByCategory(Category category, Pageable pageable);
+    List<Template> findAllByCategory(TemplateCategory templateCategory, Pageable pageable);
 }

--- a/src/main/java/com/baro/template/infra/TemplateJpaRepository.java
+++ b/src/main/java/com/baro/template/infra/TemplateJpaRepository.java
@@ -1,0 +1,12 @@
+package com.baro.template.infra;
+
+import com.baro.template.domain.Category;
+import com.baro.template.domain.Template;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TemplateJpaRepository extends JpaRepository<Template, Long> {
+
+    List<Template> findAllByCategory(Category category, Pageable pageable);
+}

--- a/src/main/java/com/baro/template/infra/TemplateRepositoryImpl.java
+++ b/src/main/java/com/baro/template/infra/TemplateRepositoryImpl.java
@@ -1,7 +1,7 @@
 package com.baro.template.infra;
 
-import com.baro.template.domain.Category;
 import com.baro.template.domain.Template;
+import com.baro.template.domain.TemplateCategory;
 import com.baro.template.domain.TemplateRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -15,8 +15,8 @@ public class TemplateRepositoryImpl implements TemplateRepository {
     private final TemplateJpaRepository templateJpaRepository;
 
     @Override
-    public List<Template> findAllByCategory(Category category, Pageable pageable) {
-        return templateJpaRepository.findAllByCategory(category, pageable);
+    public List<Template> findAllByCategory(TemplateCategory templateCategory, Pageable pageable) {
+        return templateJpaRepository.findAllByCategory(templateCategory, pageable);
     }
 
     @Override

--- a/src/main/java/com/baro/template/infra/TemplateRepositoryImpl.java
+++ b/src/main/java/com/baro/template/infra/TemplateRepositoryImpl.java
@@ -3,9 +3,9 @@ package com.baro.template.infra;
 import com.baro.template.domain.Template;
 import com.baro.template.domain.TemplateCategory;
 import com.baro.template.domain.TemplateRepository;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Repository;
 
 @RequiredArgsConstructor
@@ -15,7 +15,7 @@ public class TemplateRepositoryImpl implements TemplateRepository {
     private final TemplateJpaRepository templateJpaRepository;
 
     @Override
-    public List<Template> findAllByCategory(TemplateCategory templateCategory, Pageable pageable) {
+    public Slice<Template> findAllByCategory(TemplateCategory templateCategory, Pageable pageable) {
         return templateJpaRepository.findAllByCategory(templateCategory, pageable);
     }
 

--- a/src/main/java/com/baro/template/infra/TemplateRepositoryImpl.java
+++ b/src/main/java/com/baro/template/infra/TemplateRepositoryImpl.java
@@ -1,0 +1,26 @@
+package com.baro.template.infra;
+
+import com.baro.template.domain.Category;
+import com.baro.template.domain.Template;
+import com.baro.template.domain.TemplateRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class TemplateRepositoryImpl implements TemplateRepository {
+
+    private final TemplateJpaRepository templateJpaRepository;
+
+    @Override
+    public List<Template> findAllByCategory(Category category, Pageable pageable) {
+        return templateJpaRepository.findAllByCategory(category, pageable);
+    }
+
+    @Override
+    public int count() {
+        return (int) templateJpaRepository.count();
+    }
+}

--- a/src/main/java/com/baro/template/infra/TemplateRepositoryImpl.java
+++ b/src/main/java/com/baro/template/infra/TemplateRepositoryImpl.java
@@ -20,6 +20,11 @@ public class TemplateRepositoryImpl implements TemplateRepository {
     }
 
     @Override
+    public Template save(Template template) {
+        return templateJpaRepository.save(template);
+    }
+
+    @Override
     public int count() {
         return (int) templateJpaRepository.count();
     }

--- a/src/main/java/com/baro/template/infra/TemplateRepositoryImpl.java
+++ b/src/main/java/com/baro/template/infra/TemplateRepositoryImpl.java
@@ -23,9 +23,4 @@ public class TemplateRepositoryImpl implements TemplateRepository {
     public Template save(Template template) {
         return templateJpaRepository.save(template);
     }
-
-    @Override
-    public int count() {
-        return (int) templateJpaRepository.count();
-    }
 }

--- a/src/main/java/com/baro/template/presentation/SortType.java
+++ b/src/main/java/com/baro/template/presentation/SortType.java
@@ -1,0 +1,28 @@
+package com.baro.template.presentation;
+
+import com.baro.template.domain.Template;
+import com.baro.template.exception.SortException;
+import com.baro.template.exception.SortExceptionType;
+import java.util.Arrays;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
+
+@RequiredArgsConstructor
+@Getter
+public enum SortType {
+
+    NEW(Sort.TypedSort.sort(Template.class).by(Template::getCreatedAt).descending()),
+    COPY(Sort.TypedSort.sort(Template.class).by(Template::getCopiedCount).descending()),
+    SAVE(Sort.TypedSort.sort(Template.class).by(Template::getSavedCount).descending());
+
+    private final Sort sort;
+
+    public static Sort getSort(String sortName) {
+        return Arrays.stream(SortType.values())
+                .filter(sortType -> sortType.name().equalsIgnoreCase(sortName))
+                .findFirst()
+                .orElseThrow(() -> new SortException(SortExceptionType.INVALID_SORT_TYPE))
+                .getSort();
+    }
+}

--- a/src/main/java/com/baro/template/presentation/TemplateController.java
+++ b/src/main/java/com/baro/template/presentation/TemplateController.java
@@ -5,8 +5,8 @@ import com.baro.template.application.TemplateService;
 import com.baro.template.application.dto.FindTemplateQuery;
 import com.baro.template.application.dto.FindTemplateResult;
 import com.baro.template.domain.TemplateCategory;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -23,14 +23,14 @@ public class TemplateController {
     private final TemplateService templateService;
 
     @GetMapping("/{category}")
-    ResponseEntity<List<FindTemplateResult>> findTemplates(
+    ResponseEntity<Slice<FindTemplateResult>> findTemplates(
             AuthMember authMember,
             @PathVariable("category") String categoryName,
             @RequestParam("sort") String sortName
     ) {
         Sort sort = SortType.getSort(sortName);
         FindTemplateQuery query = new FindTemplateQuery(TemplateCategory.getCategory(categoryName), sort);
-        List<FindTemplateResult> result = templateService.findTemplates(query);
+        Slice<FindTemplateResult> result = templateService.findTemplates(query);
 
         return ResponseEntity.ok().body(result);
     }

--- a/src/main/java/com/baro/template/presentation/TemplateController.java
+++ b/src/main/java/com/baro/template/presentation/TemplateController.java
@@ -32,9 +32,6 @@ public class TemplateController {
         List<FindTemplateResult> result = templateService.findTemplates(
                 new FindTemplateQuery(Category.getCategory(categoryName), sort));
 
-        if (result.isEmpty()) {
-            return ResponseEntity.noContent().build();
-        }
         return ResponseEntity.ok().body(result);
     }
 }

--- a/src/main/java/com/baro/template/presentation/TemplateController.java
+++ b/src/main/java/com/baro/template/presentation/TemplateController.java
@@ -29,8 +29,8 @@ public class TemplateController {
             @RequestParam("sort") String sortName
     ) {
         Sort sort = SortType.getSort(sortName);
-        List<FindTemplateResult> result = templateService.findTemplates(
-                new FindTemplateQuery(TemplateCategory.getCategory(categoryName), sort));
+        FindTemplateQuery query = new FindTemplateQuery(TemplateCategory.getCategory(categoryName), sort);
+        List<FindTemplateResult> result = templateService.findTemplates(query);
 
         return ResponseEntity.ok().body(result);
     }

--- a/src/main/java/com/baro/template/presentation/TemplateController.java
+++ b/src/main/java/com/baro/template/presentation/TemplateController.java
@@ -1,0 +1,40 @@
+package com.baro.template.presentation;
+
+import com.baro.auth.domain.AuthMember;
+import com.baro.template.application.TemplateService;
+import com.baro.template.application.dto.FindTemplateQuery;
+import com.baro.template.application.dto.FindTemplateResult;
+import com.baro.template.domain.Category;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/templates")
+@RestController
+public class TemplateController {
+
+    private final TemplateService templateService;
+
+    @GetMapping("/{category}")
+    ResponseEntity<List<FindTemplateResult>> findTemplates(
+            AuthMember authMember,
+            @PathVariable("category") String categoryName,
+            @RequestParam("sort") String sortName
+    ) {
+        Sort sort = SortType.getSort(sortName);
+        List<FindTemplateResult> result = templateService.findTemplates(
+                new FindTemplateQuery(Category.getCategory(categoryName), sort));
+
+        if (result.isEmpty()) {
+            return ResponseEntity.noContent().build();
+        }
+        return ResponseEntity.ok().body(result);
+    }
+}

--- a/src/main/java/com/baro/template/presentation/TemplateController.java
+++ b/src/main/java/com/baro/template/presentation/TemplateController.java
@@ -4,7 +4,7 @@ import com.baro.auth.domain.AuthMember;
 import com.baro.template.application.TemplateService;
 import com.baro.template.application.dto.FindTemplateQuery;
 import com.baro.template.application.dto.FindTemplateResult;
-import com.baro.template.domain.Category;
+import com.baro.template.domain.TemplateCategory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
@@ -30,7 +30,7 @@ public class TemplateController {
     ) {
         Sort sort = SortType.getSort(sortName);
         List<FindTemplateResult> result = templateService.findTemplates(
-                new FindTemplateQuery(Category.getCategory(categoryName), sort));
+                new FindTemplateQuery(TemplateCategory.getCategory(categoryName), sort));
 
         return ResponseEntity.ok().body(result);
     }

--- a/src/test/java/com/baro/common/acceptance/AcceptanceSteps.java
+++ b/src/test/java/com/baro/common/acceptance/AcceptanceSteps.java
@@ -11,6 +11,7 @@ public class AcceptanceSteps {
 
     public static final HttpStatus 성공 = HttpStatus.OK;
     public static final HttpStatus 생성됨 = HttpStatus.CREATED;
+    public static final HttpStatus 응답값_없음 = HttpStatus.NO_CONTENT;
     public static final HttpStatus 리디렉션 = HttpStatus.MOVED_PERMANENTLY;
     public static final HttpStatus 잘못된_요청 = HttpStatus.BAD_REQUEST;
 
@@ -33,5 +34,13 @@ public class AcceptanceSteps {
             Object 값
     ) {
         assertThat(응답.body().jsonPath().getString(필드)).isEqualTo(값);
+    }
+
+    public static void 응답의_개수를_검증한다(
+            ExtractableResponse<Response> 응답,
+            String json키,
+            int 값
+    ) {
+        assertThat(응답.body().jsonPath().getList(json키)).hasSize(값);
     }
 }

--- a/src/test/java/com/baro/common/acceptance/AcceptanceSteps.java
+++ b/src/test/java/com/baro/common/acceptance/AcceptanceSteps.java
@@ -11,7 +11,6 @@ public class AcceptanceSteps {
 
     public static final HttpStatus 성공 = HttpStatus.OK;
     public static final HttpStatus 생성됨 = HttpStatus.CREATED;
-    public static final HttpStatus 응답값_없음 = HttpStatus.NO_CONTENT;
     public static final HttpStatus 리디렉션 = HttpStatus.MOVED_PERMANENTLY;
     public static final HttpStatus 잘못된_요청 = HttpStatus.BAD_REQUEST;
 

--- a/src/test/java/com/baro/common/acceptance/template/TemplateAcceptanceSteps.java
+++ b/src/test/java/com/baro/common/acceptance/template/TemplateAcceptanceSteps.java
@@ -1,0 +1,125 @@
+package com.baro.common.acceptance.template;
+
+import static com.baro.common.RestApiTest.DEFAULT_REST_DOCS_PATH;
+import static com.baro.common.RestApiTest.requestSpec;
+import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.document;
+import static io.restassured.RestAssured.given;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.restdocs.snippet.Attributes.key;
+
+import com.baro.auth.domain.Token;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+public class TemplateAcceptanceSteps {
+
+    public static ExtractableResponse<Response> 템플릿_조회_요청_성공(Token 토큰, String 카테고리, String 정렬) {
+        var url = "/templates/{category}";
+
+        return given(requestSpec).log().all()
+                .filter(document(DEFAULT_REST_DOCS_PATH,
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("인증 토큰")
+                        ),
+                        pathParameters(
+                                parameterWithName("category")
+                                        .description("카테고리")
+                                        .attributes(key("카테고리 예시").value(
+                                                "ask, report, celebrate, thank, comfort, regard, etc"))
+                        ),
+                        queryParameters(
+                                parameterWithName("sort")
+                                        .description("정렬")
+                                        .attributes(key("정렬 예시").value(
+                                                "new, copy, save"))
+                        ),
+                        responseFields(
+                                fieldWithPath("[].templateId").description("템플릿 id"),
+                                fieldWithPath("[].category").description("카테고리 이름"),
+                                fieldWithPath("[].subCategory").description("서브 카테고리 이름"),
+                                fieldWithPath("[].content").description("템플릿 내용"),
+                                fieldWithPath("[].savedCount").description("저장 횟수"),
+                                fieldWithPath("[].copiedCount").description("복사 횟수")
+                        ))
+                )
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + 토큰.accessToken())
+                .pathParam("category", 카테고리)
+                .queryParam("sort", 정렬)
+                .when().get(url)
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 템플릿_조회시_응답값이_없는_요청(Token 토큰, String 카테고리, String 정렬) {
+        var url = "/templates/{category}";
+
+        return given(requestSpec).log().all()
+                .filter(document(DEFAULT_REST_DOCS_PATH,
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("인증 토큰")
+                        ),
+                        pathParameters(
+                                parameterWithName("category")
+                                        .description("카테고리")
+                                        .attributes(key("카테고리 예시").value(
+                                                "ask, report, celebrate, thank, comfort, regard, etc"))
+                        ),
+                        queryParameters(
+                                parameterWithName("sort")
+                                        .description("정렬")
+                                        .attributes(key("정렬 예시").value(
+                                                "new, copy, save"))
+                        )
+                ))
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + 토큰.accessToken())
+                .pathParam("category", 카테고리)
+                .queryParam("sort", 정렬)
+                .when().get(url)
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 템플릿_조회_요청_실패(Token 토큰, String 카테고리, String 정렬) {
+        var url = "/templates/{category}";
+
+        return given(requestSpec).log().all()
+                .filter(document(DEFAULT_REST_DOCS_PATH,
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("인증 토큰")
+                        ),
+                        pathParameters(
+                                parameterWithName("category")
+                                        .description("카테고리")
+                                        .attributes(key("카테고리 예시").value(
+                                                "ask, report, celebrate, thank, comfort, regard, etc"))
+                        ),
+                        queryParameters(
+                                parameterWithName("sort")
+                                        .description("정렬")
+                                        .attributes(key("정렬 예시").value(
+                                                "new, copy, save"))
+                        ),
+                        responseFields(
+                                fieldWithPath("errorCode").description("에러 코드"),
+                                fieldWithPath("errorMessage").description("에러 메시지")
+                        ))
+                )
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + 토큰.accessToken())
+                .queryParam("sort", 정렬)
+                .pathParam("category", 카테고리)
+                .when().get(url)
+                .then().log().all()
+                .extract();
+    }
+}

--- a/src/test/java/com/baro/common/acceptance/template/TemplateAcceptanceSteps.java
+++ b/src/test/java/com/baro/common/acceptance/template/TemplateAcceptanceSteps.java
@@ -16,8 +16,11 @@ import static org.springframework.restdocs.snippet.Attributes.key;
 import com.baro.auth.domain.Token;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import java.util.ArrayList;
+import java.util.List;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.FieldDescriptor;
 
 public class TemplateAcceptanceSteps {
 
@@ -42,12 +45,7 @@ public class TemplateAcceptanceSteps {
                                                 "new, copy, save"))
                         ),
                         responseFields(
-                                fieldWithPath("[].templateId").description("템플릿 id"),
-                                fieldWithPath("[].category").description("카테고리 이름"),
-                                fieldWithPath("[].subCategory").description("서브 카테고리 이름"),
-                                fieldWithPath("[].content").description("템플릿 내용"),
-                                fieldWithPath("[].savedCount").description("저장 횟수"),
-                                fieldWithPath("[].copiedCount").description("복사 횟수")
+                                content_결괏값이_있는_템플릿_페이지네이션_조회_Slice_필드()
                         ))
                 )
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -78,6 +76,9 @@ public class TemplateAcceptanceSteps {
                                         .description("정렬")
                                         .attributes(key("정렬 예시").value(
                                                 "new, copy, save"))
+                        ),
+                        responseFields(
+                                content_결괏값이_없는_템플릿_페이지네이션_조회_Slice_필드()
                         )
                 ))
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -98,16 +99,13 @@ public class TemplateAcceptanceSteps {
                                 headerWithName(HttpHeaders.AUTHORIZATION).description("인증 토큰")
                         ),
                         pathParameters(
-                                parameterWithName("category")
-                                        .description("카테고리")
+                                parameterWithName("category").description("카테고리")
                                         .attributes(key("카테고리 예시").value(
                                                 "ask, report, celebrate, thank, comfort, regard, etc"))
                         ),
                         queryParameters(
-                                parameterWithName("sort")
-                                        .description("정렬")
-                                        .attributes(key("정렬 예시").value(
-                                                "new, copy, save"))
+                                parameterWithName("sort").description("정렬")
+                                        .attributes(key("정렬 예시").value("new, copy, save"))
                         ),
                         responseFields(
                                 fieldWithPath("errorCode").description("에러 코드"),
@@ -121,5 +119,49 @@ public class TemplateAcceptanceSteps {
                 .when().get(url)
                 .then().log().all()
                 .extract();
+    }
+
+    private static List<FieldDescriptor> content_결괏값이_있는_템플릿_페이지네이션_조회_Slice_필드() {
+        var responseFields = new ArrayList<>(content_결괏값이_없는_템플릿_페이지네이션_조회_Slice_필드());
+        responseFields.addAll(템플릿_content());
+        return responseFields;
+    }
+
+
+    private static List<FieldDescriptor> content_결괏값이_없는_템플릿_페이지네이션_조회_Slice_필드() {
+        return List.of(
+                fieldWithPath("content").description("템플릿 데이터"),
+                fieldWithPath("pageable").description("페이지 정보"),
+                fieldWithPath("pageable.pageNumber").description("현재 페이지 번호"),
+                fieldWithPath("pageable.pageSize").description("한 페이지에 표시될 항목 수"),
+                fieldWithPath("pageable.sort").description("정렬에 관한 정보"),
+                fieldWithPath("pageable.sort.empty").description("정렬이 비어있는지 여부"),
+                fieldWithPath("pageable.sort.sorted").description("정렬 여부"),
+                fieldWithPath("pageable.sort.unsorted").description("정렬 여부"),
+                fieldWithPath("pageable.offset").description("현재 페이지의 오프셋"),
+                fieldWithPath("pageable.paged").description("페이징이 적용되었는지 여부"),
+                fieldWithPath("pageable.unpaged").description("페이징이 적용되지 않았는지 여부"),
+                fieldWithPath("size").description("현재 페이지의 항목 사이즈"),
+                fieldWithPath("number").description("현재 페이지 번호"),
+                fieldWithPath("sort").description("정렬에 관한 정보"),
+                fieldWithPath("sort.empty").description("정렬 유무"),
+                fieldWithPath("sort.sorted").description("정렬 여부"),
+                fieldWithPath("sort.unsorted").description("정렬 여부"),
+                fieldWithPath("last").description("현재 페이지가 마지막 페이지인지 여부"),
+                fieldWithPath("first").description("현재 페이지가 첫 페이지인지 여부"),
+                fieldWithPath("numberOfElements").description("현재 페이지의 항목 수"),
+                fieldWithPath("empty").description("현재 페이지가 비어있는지 여부")
+        );
+    }
+
+    private static List<FieldDescriptor> 템플릿_content() {
+        return List.of(
+                fieldWithPath("content[].templateId").description("템플릿 id"),
+                fieldWithPath("content[].category").description("템플릿 카테고리"),
+                fieldWithPath("content[].subCategory").description("템플릿 서브 카테고리"),
+                fieldWithPath("content[].content").description("템플릿 내용"),
+                fieldWithPath("content[].savedCount").description("템플릿 저장 횟수"),
+                fieldWithPath("content[].copiedCount").description("템플릿 복사 횟수")
+        );
     }
 }

--- a/src/test/java/com/baro/common/acceptance/template/TemplateAcceptanceSteps.java
+++ b/src/test/java/com/baro/common/acceptance/template/TemplateAcceptanceSteps.java
@@ -2,6 +2,7 @@ package com.baro.common.acceptance.template;
 
 import static com.baro.common.RestApiTest.DEFAULT_REST_DOCS_PATH;
 import static com.baro.common.RestApiTest.requestSpec;
+import static com.baro.common.acceptance.AcceptanceSteps.예외_응답;
 import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.document;
 import static io.restassured.RestAssured.given;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
@@ -105,11 +106,8 @@ public class TemplateAcceptanceSteps {
                                 parameterWithName("sort").description("정렬")
                                         .attributes(key("정렬 예시").value("new, copy, save"))
                         ),
-                        responseFields(
-                                fieldWithPath("errorCode").description("에러 코드"),
-                                fieldWithPath("errorMessage").description("에러 메시지")
-                        ))
-                )
+                        responseFields(예외_응답())
+                ))
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + 토큰.accessToken())
                 .queryParam("sort", 정렬)

--- a/src/test/java/com/baro/common/acceptance/template/TemplateAcceptanceSteps.java
+++ b/src/test/java/com/baro/common/acceptance/template/TemplateAcceptanceSteps.java
@@ -16,7 +16,6 @@ import static org.springframework.restdocs.snippet.Attributes.key;
 import com.baro.auth.domain.Token;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import java.util.ArrayList;
 import java.util.List;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -45,9 +44,10 @@ public class TemplateAcceptanceSteps {
                                                 "new, copy, save"))
                         ),
                         responseFields(
-                                content_결괏값이_있는_템플릿_페이지네이션_조회_Slice_필드()
-                        ))
-                )
+                                페이지네이션_조회_필드()
+                        )
+                                .and(템플릿_content())
+                ))
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + 토큰.accessToken())
                 .pathParam("category", 카테고리)
@@ -77,9 +77,7 @@ public class TemplateAcceptanceSteps {
                                         .attributes(key("정렬 예시").value(
                                                 "new, copy, save"))
                         ),
-                        responseFields(
-                                content_결괏값이_없는_템플릿_페이지네이션_조회_Slice_필드()
-                        )
+                        responseFields(페이지네이션_조회_필드())
                 ))
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + 토큰.accessToken())
@@ -121,14 +119,7 @@ public class TemplateAcceptanceSteps {
                 .extract();
     }
 
-    private static List<FieldDescriptor> content_결괏값이_있는_템플릿_페이지네이션_조회_Slice_필드() {
-        var responseFields = new ArrayList<>(content_결괏값이_없는_템플릿_페이지네이션_조회_Slice_필드());
-        responseFields.addAll(템플릿_content());
-        return responseFields;
-    }
-
-
-    private static List<FieldDescriptor> content_결괏값이_없는_템플릿_페이지네이션_조회_Slice_필드() {
+    private static List<FieldDescriptor> 페이지네이션_조회_필드() {
         return List.of(
                 fieldWithPath("content").description("템플릿 데이터"),
                 fieldWithPath("pageable").description("페이지 정보"),

--- a/src/test/java/com/baro/template/application/TemplateServiceTest.java
+++ b/src/test/java/com/baro/template/application/TemplateServiceTest.java
@@ -1,0 +1,86 @@
+package com.baro.template.application;
+
+import static com.baro.template.fixture.TemplateFixture.감사전하기;
+import static com.baro.template.fixture.TemplateFixture.보고하기;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.baro.template.application.dto.FindTemplateQuery;
+import com.baro.template.domain.Category;
+import com.baro.template.domain.Template;
+import com.baro.template.domain.TemplateRepository;
+import com.baro.template.fake.FakeTemplateRepository;
+import com.baro.template.presentation.SortType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class TemplateServiceTest {
+
+    private TemplateService service;
+    private TemplateRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        repository = new FakeTemplateRepository();
+        service = new TemplateService(repository);
+    }
+
+    @Test
+    void 최신순_템플릿_조회() {
+        // given
+        Template template1 = repository.save(보고하기());
+        Template template2 = repository.save(보고하기());
+        Template template3 = repository.save(보고하기());
+        Template template4 = repository.save(감사전하기());
+
+        // when
+        var result = service.findTemplates(new FindTemplateQuery(Category.REPORT, SortType.NEW.getSort()));
+
+        // then
+        assertThat(result).hasSize(3);
+        assertThat(result.get(0).templateId()).isEqualTo(template3.getId());
+    }
+
+    @Test
+    void 복사순_템플릿_조회() {
+        // given
+        Template template1 = repository.save(보고하기(0, 0));
+        Template template2 = repository.save(보고하기(0, 1));
+        Template template3 = repository.save(보고하기(0, 2));
+        Template template4 = repository.save(감사전하기(0, 3));
+
+        // when
+        var result = service.findTemplates(new FindTemplateQuery(Category.REPORT, SortType.COPY.getSort()));
+
+        // then
+        assertThat(result).hasSize(3);
+        assertThat(result.get(0).templateId()).isEqualTo(template3.getId());
+    }
+
+    @Test
+    void 저장순_템플릿_조회() {
+        // given
+        Template template1 = repository.save(보고하기(0, 0));
+        Template template2 = repository.save(보고하기(1, 0));
+        Template template3 = repository.save(보고하기(2, 0));
+        Template template4 = repository.save(감사전하기(3, 0));
+
+        // when
+        var result = service.findTemplates(new FindTemplateQuery(Category.REPORT, SortType.SAVE.getSort()));
+
+        // then
+        assertThat(result.get(0).templateId()).isEqualTo(template3.getId());
+    }
+
+    @Test
+    void 빈_템플릿_조회() {
+        // when
+        var result = service.findTemplates(new FindTemplateQuery(Category.REPORT, SortType.NEW.getSort()));
+
+        // then
+        assertThat(result).isEmpty();
+    }
+}

--- a/src/test/java/com/baro/template/application/TemplateServiceTest.java
+++ b/src/test/java/com/baro/template/application/TemplateServiceTest.java
@@ -5,11 +5,13 @@ import static com.baro.template.fixture.TemplateFixture.보고하기;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.baro.template.application.dto.FindTemplateQuery;
+import com.baro.template.application.dto.FindTemplateResult;
 import com.baro.template.domain.Template;
 import com.baro.template.domain.TemplateCategory;
 import com.baro.template.domain.TemplateRepository;
 import com.baro.template.fake.FakeTemplateRepository;
 import com.baro.template.presentation.SortType;
+import java.util.Comparator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
@@ -57,7 +59,7 @@ class TemplateServiceTest {
 
         // then
         assertThat(result).hasSize(3);
-        assertThat(result.get(0).templateId()).isEqualTo(template3.getId());
+        assertThat(result).isSortedAccordingTo(Comparator.comparing(FindTemplateResult::copiedCount).reversed());
     }
 
     @Test
@@ -73,6 +75,7 @@ class TemplateServiceTest {
 
         // then
         assertThat(result.get(0).templateId()).isEqualTo(template3.getId());
+        assertThat(result).isSortedAccordingTo(Comparator.comparing(FindTemplateResult::savedCount).reversed());
     }
 
     @Test

--- a/src/test/java/com/baro/template/application/TemplateServiceTest.java
+++ b/src/test/java/com/baro/template/application/TemplateServiceTest.java
@@ -5,8 +5,8 @@ import static com.baro.template.fixture.TemplateFixture.보고하기;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.baro.template.application.dto.FindTemplateQuery;
-import com.baro.template.domain.Category;
 import com.baro.template.domain.Template;
+import com.baro.template.domain.TemplateCategory;
 import com.baro.template.domain.TemplateRepository;
 import com.baro.template.fake.FakeTemplateRepository;
 import com.baro.template.presentation.SortType;
@@ -37,7 +37,7 @@ class TemplateServiceTest {
         Template template4 = repository.save(감사전하기());
 
         // when
-        var result = service.findTemplates(new FindTemplateQuery(Category.REPORT, SortType.NEW.getSort()));
+        var result = service.findTemplates(new FindTemplateQuery(TemplateCategory.REPORT, SortType.NEW.getSort()));
 
         // then
         assertThat(result).hasSize(3);
@@ -53,7 +53,7 @@ class TemplateServiceTest {
         Template template4 = repository.save(감사전하기(0, 3));
 
         // when
-        var result = service.findTemplates(new FindTemplateQuery(Category.REPORT, SortType.COPY.getSort()));
+        var result = service.findTemplates(new FindTemplateQuery(TemplateCategory.REPORT, SortType.COPY.getSort()));
 
         // then
         assertThat(result).hasSize(3);
@@ -69,7 +69,7 @@ class TemplateServiceTest {
         Template template4 = repository.save(감사전하기(3, 0));
 
         // when
-        var result = service.findTemplates(new FindTemplateQuery(Category.REPORT, SortType.SAVE.getSort()));
+        var result = service.findTemplates(new FindTemplateQuery(TemplateCategory.REPORT, SortType.SAVE.getSort()));
 
         // then
         assertThat(result.get(0).templateId()).isEqualTo(template3.getId());
@@ -78,7 +78,7 @@ class TemplateServiceTest {
     @Test
     void 빈_템플릿_조회() {
         // when
-        var result = service.findTemplates(new FindTemplateQuery(Category.REPORT, SortType.NEW.getSort()));
+        var result = service.findTemplates(new FindTemplateQuery(TemplateCategory.REPORT, SortType.NEW.getSort()));
 
         // then
         assertThat(result).isEmpty();

--- a/src/test/java/com/baro/template/application/TemplateServiceTest.java
+++ b/src/test/java/com/baro/template/application/TemplateServiceTest.java
@@ -42,9 +42,11 @@ class TemplateServiceTest {
         var result = service.findTemplates(new FindTemplateQuery(TemplateCategory.REPORT, SortType.NEW.getSort()));
 
         // then
-        assertThat(result.getContent()).hasSize(3);
-        assertThat(result.getContent()).isSortedAccordingTo(
-                Comparator.comparing(FindTemplateResult::templateId).reversed());
+        assertAll(
+                () -> assertThat(result.getContent()).hasSize(3),
+                () -> assertThat(result.getContent()).isSortedAccordingTo(
+                        Comparator.comparing(FindTemplateResult::templateId).reversed())
+        );
     }
 
     @Test

--- a/src/test/java/com/baro/template/application/TemplateServiceTest.java
+++ b/src/test/java/com/baro/template/application/TemplateServiceTest.java
@@ -3,6 +3,7 @@ package com.baro.template.application;
 import static com.baro.template.fixture.TemplateFixture.감사전하기;
 import static com.baro.template.fixture.TemplateFixture.보고하기;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.baro.template.application.dto.FindTemplateQuery;
 import com.baro.template.application.dto.FindTemplateResult;
@@ -41,8 +42,9 @@ class TemplateServiceTest {
         var result = service.findTemplates(new FindTemplateQuery(TemplateCategory.REPORT, SortType.NEW.getSort()));
 
         // then
-        assertThat(result).hasSize(3);
-        assertThat(result).isSortedAccordingTo(Comparator.comparing(FindTemplateResult::templateId).reversed());
+        assertThat(result.getContent()).hasSize(3);
+        assertThat(result.getContent()).isSortedAccordingTo(
+                Comparator.comparing(FindTemplateResult::templateId).reversed());
     }
 
     @Test
@@ -57,8 +59,11 @@ class TemplateServiceTest {
         var result = service.findTemplates(new FindTemplateQuery(TemplateCategory.REPORT, SortType.COPY.getSort()));
 
         // then
-        assertThat(result).hasSize(3);
-        assertThat(result).isSortedAccordingTo(Comparator.comparing(FindTemplateResult::copiedCount).reversed());
+        assertAll(
+                () -> assertThat(result.getNumberOfElements()).isEqualTo(3),
+                () -> assertThat(result.getContent()).isSortedAccordingTo(
+                        Comparator.comparing(FindTemplateResult::copiedCount).reversed())
+        );
     }
 
     @Test
@@ -73,8 +78,11 @@ class TemplateServiceTest {
         var result = service.findTemplates(new FindTemplateQuery(TemplateCategory.REPORT, SortType.SAVE.getSort()));
 
         // then
-        assertThat(result).hasSize(3);
-        assertThat(result).isSortedAccordingTo(Comparator.comparing(FindTemplateResult::savedCount).reversed());
+        assertAll(
+                () -> assertThat(result.getNumberOfElements()).isEqualTo(3),
+                () -> assertThat(result.getContent()).isSortedAccordingTo(
+                        Comparator.comparing(FindTemplateResult::savedCount).reversed())
+        );
     }
 
     @Test
@@ -83,6 +91,11 @@ class TemplateServiceTest {
         var result = service.findTemplates(new FindTemplateQuery(TemplateCategory.REPORT, SortType.NEW.getSort()));
 
         // then
-        assertThat(result).isEmpty();
+        assertAll(
+                () -> assertThat(result.getContent()).isEmpty(),
+                () -> assertThat(result.getNumberOfElements()).isEqualTo(0),
+                () -> assertThat(result.isFirst()).isEqualTo(true),
+                () -> assertThat(result.isLast()).isEqualTo(true)
+        );
     }
 }

--- a/src/test/java/com/baro/template/application/TemplateServiceTest.java
+++ b/src/test/java/com/baro/template/application/TemplateServiceTest.java
@@ -6,7 +6,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.baro.template.application.dto.FindTemplateQuery;
 import com.baro.template.application.dto.FindTemplateResult;
-import com.baro.template.domain.Template;
 import com.baro.template.domain.TemplateCategory;
 import com.baro.template.domain.TemplateRepository;
 import com.baro.template.fake.FakeTemplateRepository;
@@ -33,26 +32,26 @@ class TemplateServiceTest {
     @Test
     void 최신순_템플릿_조회() {
         // given
-        Template template1 = repository.save(보고하기());
-        Template template2 = repository.save(보고하기());
-        Template template3 = repository.save(보고하기());
-        Template template4 = repository.save(감사전하기());
+        repository.save(보고하기());
+        repository.save(보고하기());
+        repository.save(보고하기());
+        repository.save(감사전하기());
 
         // when
         var result = service.findTemplates(new FindTemplateQuery(TemplateCategory.REPORT, SortType.NEW.getSort()));
 
         // then
         assertThat(result).hasSize(3);
-        assertThat(result.get(0).templateId()).isEqualTo(template3.getId());
+        assertThat(result).isSortedAccordingTo(Comparator.comparing(FindTemplateResult::templateId).reversed());
     }
 
     @Test
     void 복사순_템플릿_조회() {
         // given
-        Template template1 = repository.save(보고하기(0, 0));
-        Template template2 = repository.save(보고하기(0, 1));
-        Template template3 = repository.save(보고하기(0, 2));
-        Template template4 = repository.save(감사전하기(0, 3));
+        repository.save(보고하기(0, 0));
+        repository.save(보고하기(0, 1));
+        repository.save(보고하기(0, 2));
+        repository.save(감사전하기(0, 3));
 
         // when
         var result = service.findTemplates(new FindTemplateQuery(TemplateCategory.REPORT, SortType.COPY.getSort()));
@@ -65,16 +64,16 @@ class TemplateServiceTest {
     @Test
     void 저장순_템플릿_조회() {
         // given
-        Template template1 = repository.save(보고하기(0, 0));
-        Template template2 = repository.save(보고하기(1, 0));
-        Template template3 = repository.save(보고하기(2, 0));
-        Template template4 = repository.save(감사전하기(3, 0));
+        repository.save(보고하기(0, 0));
+        repository.save(보고하기(1, 0));
+        repository.save(보고하기(2, 0));
+        repository.save(감사전하기(3, 0));
 
         // when
         var result = service.findTemplates(new FindTemplateQuery(TemplateCategory.REPORT, SortType.SAVE.getSort()));
 
         // then
-        assertThat(result.get(0).templateId()).isEqualTo(template3.getId());
+        assertThat(result).hasSize(3);
         assertThat(result).isSortedAccordingTo(Comparator.comparing(FindTemplateResult::savedCount).reversed());
     }
 

--- a/src/test/java/com/baro/template/domain/CategoryTest.java
+++ b/src/test/java/com/baro/template/domain/CategoryTest.java
@@ -1,0 +1,39 @@
+package com.baro.template.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.baro.template.exception.TemplateException;
+import com.baro.template.exception.TemplateExceptionType;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class CategoryTest {
+
+    @Test
+    void 해당하는_카테고리를_반환한다() {
+        // given
+        var category = "report";
+
+        // when
+        var result = Category.getCategory(category);
+
+        // then
+        assertThat(result).isEqualTo(Category.REPORT);
+    }
+
+    @Test
+    void 해당하는_카테고리가_없을_경우_예외를_반환한다() {
+        // given
+        var category = "nothing";
+
+        // when & then
+        assertThatThrownBy(() -> Category.getCategory(category))
+                .isInstanceOf(TemplateException.class)
+                .extracting("exceptionType")
+                .isEqualTo(TemplateExceptionType.INVALID_CATEGORY);
+    }
+}

--- a/src/test/java/com/baro/template/domain/TemplateCategoryTest.java
+++ b/src/test/java/com/baro/template/domain/TemplateCategoryTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 
 @DisplayNameGeneration(ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
-class CategoryTest {
+class TemplateCategoryTest {
 
     @Test
     void 해당하는_카테고리를_반환한다() {
@@ -19,10 +19,10 @@ class CategoryTest {
         var category = "report";
 
         // when
-        var result = Category.getCategory(category);
+        var result = TemplateCategory.getCategory(category);
 
         // then
-        assertThat(result).isEqualTo(Category.REPORT);
+        assertThat(result).isEqualTo(TemplateCategory.REPORT);
     }
 
     @Test
@@ -31,7 +31,7 @@ class CategoryTest {
         var category = "nothing";
 
         // when & then
-        assertThatThrownBy(() -> Category.getCategory(category))
+        assertThatThrownBy(() -> TemplateCategory.getCategory(category))
                 .isInstanceOf(TemplateException.class)
                 .extracting("exceptionType")
                 .isEqualTo(TemplateExceptionType.INVALID_CATEGORY);

--- a/src/test/java/com/baro/template/fake/FakeTemplateRepository.java
+++ b/src/test/java/com/baro/template/fake/FakeTemplateRepository.java
@@ -26,12 +26,11 @@ public class FakeTemplateRepository implements TemplateRepository {
     @Override
     public List<Template> findAllByCategory(TemplateCategory templateCategory, Pageable pageable) {
         List<Template> categorizedTemplates = templates.values().stream()
-                .filter(template -> template.getTemplateCategory().equals(templateCategory))
+                .filter(template -> template.getCategory().equals(templateCategory))
                 .toList();
 
         int start = (int) pageable.getOffset();
         int end = Math.min((start + pageable.getPageSize()), categorizedTemplates.size());
-
         Sort sortType = pageable.getSort();
 
         categorizedTemplates = sort(sortType, categorizedTemplates);
@@ -43,7 +42,7 @@ public class FakeTemplateRepository implements TemplateRepository {
     public Template save(Template template) {
         if (Objects.isNull(template.getId())) {
             Long templateId = id.getAndIncrement();
-            Template newTemplate = instanceForTest(templateId, template.getTemplateCategory(),
+            Template newTemplate = instanceForTest(templateId, template.getCategory(),
                     template.getSubCategory(),
                     template.getContent(), template.getSavedCount(), template.getCopiedCount());
             templates.put(templateId, newTemplate);

--- a/src/test/java/com/baro/template/fake/FakeTemplateRepository.java
+++ b/src/test/java/com/baro/template/fake/FakeTemplateRepository.java
@@ -1,0 +1,76 @@
+package com.baro.template.fake;
+
+import com.baro.template.domain.Category;
+import com.baro.template.domain.Template;
+import com.baro.template.domain.TemplateRepository;
+import com.baro.template.exception.SortException;
+import com.baro.template.exception.SortExceptionType;
+import com.baro.template.presentation.SortType;
+import io.jsonwebtoken.lang.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+public class FakeTemplateRepository implements TemplateRepository {
+
+    private final AtomicLong id = new AtomicLong(1);
+    private final Map<Long, Template> templates = new ConcurrentHashMap<>();
+
+    @Override
+    public List<Template> findAllByCategory(Category category, Pageable pageable) {
+        List<Template> categorizedTemplates = templates.values().stream()
+                .filter(template -> template.getCategory().equals(category))
+                .toList();
+
+        int start = (int) pageable.getOffset();
+        int end = Math.min((start + pageable.getPageSize()), categorizedTemplates.size());
+
+        Sort sortType = pageable.getSort();
+
+        if (sortType.equals(SortType.NEW.getSort())) {
+            categorizedTemplates = categorizedTemplates.stream()
+                    .sorted(Comparator.comparing(Template::getCreatedAt).reversed())
+                    .toList();
+        } else if (sortType.equals(SortType.COPY.getSort())) {
+            categorizedTemplates = categorizedTemplates.stream()
+                    .sorted(Comparator.comparing(Template::getCopiedCount).reversed())
+                    .toList();
+        } else if (sortType.equals(SortType.SAVE.getSort())) {
+            categorizedTemplates = categorizedTemplates.stream()
+                    .sorted(Comparator.comparing(Template::getSavedCount).reversed())
+                    .toList();
+        } else {
+            throw new SortException(SortExceptionType.INVALID_SORT_TYPE);
+        }
+
+        return categorizedTemplates.subList(start, end);
+    }
+
+    @Override
+    public Template save(Template template) {
+        if (Objects.isNull(template.getId())) {
+            Long pk = id.getAndIncrement();
+            Template newTemplate = new Template(
+                    template.getCategory(),
+                    template.getSubCategory(),
+                    template.getContent(),
+                    template.getCopiedCount(),
+                    template.getSavedCount()
+            );
+            templates.put(pk, newTemplate);
+            return newTemplate;
+        }
+        templates.put(template.getId(), template);
+        return template;
+    }
+
+    @Override
+    public int count() {
+        return Collections.size(templates.values());
+    }
+}

--- a/src/test/java/com/baro/template/fake/FakeTemplateRepository.java
+++ b/src/test/java/com/baro/template/fake/FakeTemplateRepository.java
@@ -16,6 +16,8 @@ import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.domain.Sort;
 
 public class FakeTemplateRepository implements TemplateRepository {
@@ -24,18 +26,15 @@ public class FakeTemplateRepository implements TemplateRepository {
     private final Map<Long, Template> templates = new ConcurrentHashMap<>();
 
     @Override
-    public List<Template> findAllByCategory(TemplateCategory templateCategory, Pageable pageable) {
+    public Slice<Template> findAllByCategory(TemplateCategory templateCategory, Pageable pageable) {
         List<Template> categorizedTemplates = templates.values().stream()
                 .filter(template -> template.getCategory().equals(templateCategory))
                 .toList();
-
-        int start = (int) pageable.getOffset();
-        int end = Math.min((start + pageable.getPageSize()), categorizedTemplates.size());
         Sort sortType = pageable.getSort();
 
         categorizedTemplates = sort(sortType, categorizedTemplates);
 
-        return categorizedTemplates.subList(start, end);
+        return new SliceImpl<>(categorizedTemplates, pageable, false);
     }
 
     @Override

--- a/src/test/java/com/baro/template/fake/FakeTemplateRepository.java
+++ b/src/test/java/com/baro/template/fake/FakeTemplateRepository.java
@@ -1,5 +1,7 @@
 package com.baro.template.fake;
 
+import static com.baro.template.domain.Template.instanceForTest;
+
 import com.baro.template.domain.Category;
 import com.baro.template.domain.Template;
 import com.baro.template.domain.TemplateRepository;
@@ -55,13 +57,8 @@ public class FakeTemplateRepository implements TemplateRepository {
     public Template save(Template template) {
         if (Objects.isNull(template.getId())) {
             Long pk = id.getAndIncrement();
-            Template newTemplate = new Template(
-                    template.getCategory(),
-                    template.getSubCategory(),
-                    template.getContent(),
-                    template.getCopiedCount(),
-                    template.getSavedCount()
-            );
+            Template newTemplate = instanceForTest(template.getCategory(), template.getSubCategory(),
+                    template.getContent(), template.getSavedCount(), template.getCopiedCount());
             templates.put(pk, newTemplate);
             return newTemplate;
         }

--- a/src/test/java/com/baro/template/fake/FakeTemplateRepository.java
+++ b/src/test/java/com/baro/template/fake/FakeTemplateRepository.java
@@ -2,8 +2,8 @@ package com.baro.template.fake;
 
 import static com.baro.template.domain.Template.instanceForTest;
 
-import com.baro.template.domain.Category;
 import com.baro.template.domain.Template;
+import com.baro.template.domain.TemplateCategory;
 import com.baro.template.domain.TemplateRepository;
 import com.baro.template.exception.SortException;
 import com.baro.template.exception.SortExceptionType;
@@ -24,9 +24,9 @@ public class FakeTemplateRepository implements TemplateRepository {
     private final Map<Long, Template> templates = new ConcurrentHashMap<>();
 
     @Override
-    public List<Template> findAllByCategory(Category category, Pageable pageable) {
+    public List<Template> findAllByCategory(TemplateCategory templateCategory, Pageable pageable) {
         List<Template> categorizedTemplates = templates.values().stream()
-                .filter(template -> template.getCategory().equals(category))
+                .filter(template -> template.getTemplateCategory().equals(templateCategory))
                 .toList();
 
         int start = (int) pageable.getOffset();
@@ -57,7 +57,7 @@ public class FakeTemplateRepository implements TemplateRepository {
     public Template save(Template template) {
         if (Objects.isNull(template.getId())) {
             Long pk = id.getAndIncrement();
-            Template newTemplate = instanceForTest(template.getCategory(), template.getSubCategory(),
+            Template newTemplate = instanceForTest(template.getTemplateCategory(), template.getSubCategory(),
                     template.getContent(), template.getSavedCount(), template.getCopiedCount());
             templates.put(pk, newTemplate);
             return newTemplate;

--- a/src/test/java/com/baro/template/fake/FakeTemplateRepository.java
+++ b/src/test/java/com/baro/template/fake/FakeTemplateRepository.java
@@ -34,6 +34,31 @@ public class FakeTemplateRepository implements TemplateRepository {
 
         Sort sortType = pageable.getSort();
 
+        categorizedTemplates = sort(sortType, categorizedTemplates);
+
+        return categorizedTemplates.subList(start, end);
+    }
+
+    @Override
+    public Template save(Template template) {
+        if (Objects.isNull(template.getId())) {
+            Long templateId = id.getAndIncrement();
+            Template newTemplate = instanceForTest(templateId, template.getTemplateCategory(),
+                    template.getSubCategory(),
+                    template.getContent(), template.getSavedCount(), template.getCopiedCount());
+            templates.put(templateId, newTemplate);
+            return newTemplate;
+        }
+        templates.put(template.getId(), template);
+        return template;
+    }
+
+    @Override
+    public int count() {
+        return Collections.size(templates.values());
+    }
+
+    private List<Template> sort(Sort sortType, List<Template> categorizedTemplates) {
         if (sortType.equals(SortType.NEW.getSort())) {
             categorizedTemplates = categorizedTemplates.stream()
                     .sorted(Comparator.comparing(Template::getCreatedAt).reversed())
@@ -49,25 +74,6 @@ public class FakeTemplateRepository implements TemplateRepository {
         } else {
             throw new SortException(SortExceptionType.INVALID_SORT_TYPE);
         }
-
-        return categorizedTemplates.subList(start, end);
-    }
-
-    @Override
-    public Template save(Template template) {
-        if (Objects.isNull(template.getId())) {
-            Long pk = id.getAndIncrement();
-            Template newTemplate = instanceForTest(template.getTemplateCategory(), template.getSubCategory(),
-                    template.getContent(), template.getSavedCount(), template.getCopiedCount());
-            templates.put(pk, newTemplate);
-            return newTemplate;
-        }
-        templates.put(template.getId(), template);
-        return template;
-    }
-
-    @Override
-    public int count() {
-        return Collections.size(templates.values());
+        return categorizedTemplates;
     }
 }

--- a/src/test/java/com/baro/template/fake/FakeTemplateRepository.java
+++ b/src/test/java/com/baro/template/fake/FakeTemplateRepository.java
@@ -8,7 +8,6 @@ import com.baro.template.domain.TemplateRepository;
 import com.baro.template.exception.SortException;
 import com.baro.template.exception.SortExceptionType;
 import com.baro.template.presentation.SortType;
-import io.jsonwebtoken.lang.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -49,11 +48,6 @@ public class FakeTemplateRepository implements TemplateRepository {
         }
         templates.put(template.getId(), template);
         return template;
-    }
-
-    @Override
-    public int count() {
-        return Collections.size(templates.values());
     }
 
     private List<Template> sort(Sort sortType, List<Template> categorizedTemplates) {

--- a/src/test/java/com/baro/template/fixture/TemplateFixture.java
+++ b/src/test/java/com/baro/template/fixture/TemplateFixture.java
@@ -1,0 +1,23 @@
+package com.baro.template.fixture;
+
+import com.baro.template.domain.Category;
+import com.baro.template.domain.Template;
+
+public class TemplateFixture {
+
+    public static Template 보고하기(int savedCount, int copiedCount) {
+        return new Template(Category.REPORT, "상사", "content", savedCount, copiedCount);
+    }
+
+    public static Template 보고하기() {
+        return 보고하기(0, 0);
+    }
+
+    public static Template 감사전하기(int savedCount, int copiedCount) {
+        return new Template(Category.THANK, "후배", "content", savedCount, copiedCount);
+    }
+
+    public static Template 감사전하기() {
+        return 감사전하기(0, 0);
+    }
+}

--- a/src/test/java/com/baro/template/fixture/TemplateFixture.java
+++ b/src/test/java/com/baro/template/fixture/TemplateFixture.java
@@ -1,12 +1,14 @@
 package com.baro.template.fixture;
 
+import static com.baro.template.domain.Template.instanceForTest;
+
 import com.baro.template.domain.Category;
 import com.baro.template.domain.Template;
 
 public class TemplateFixture {
 
     public static Template 보고하기(int savedCount, int copiedCount) {
-        return new Template(Category.REPORT, "상사", "content", savedCount, copiedCount);
+        return instanceForTest(Category.REPORT, "상사", "content", savedCount, copiedCount);
     }
 
     public static Template 보고하기() {
@@ -14,7 +16,7 @@ public class TemplateFixture {
     }
 
     public static Template 감사전하기(int savedCount, int copiedCount) {
-        return new Template(Category.THANK, "후배", "content", savedCount, copiedCount);
+        return instanceForTest(Category.THANK, "후배", "content", savedCount, copiedCount);
     }
 
     public static Template 감사전하기() {

--- a/src/test/java/com/baro/template/fixture/TemplateFixture.java
+++ b/src/test/java/com/baro/template/fixture/TemplateFixture.java
@@ -4,11 +4,14 @@ import static com.baro.template.domain.Template.instanceForTest;
 
 import com.baro.template.domain.Template;
 import com.baro.template.domain.TemplateCategory;
+import java.util.concurrent.atomic.AtomicLong;
 
 public class TemplateFixture {
 
+    private static final AtomicLong id = new AtomicLong(1);
+
     public static Template 보고하기(int savedCount, int copiedCount) {
-        return instanceForTest(TemplateCategory.REPORT, "상사", "content", savedCount, copiedCount);
+        return instanceForTest(id.getAndIncrement(), TemplateCategory.REPORT, "상사", "content", savedCount, copiedCount);
     }
 
     public static Template 보고하기() {
@@ -16,7 +19,7 @@ public class TemplateFixture {
     }
 
     public static Template 감사전하기(int savedCount, int copiedCount) {
-        return instanceForTest(TemplateCategory.THANK, "후배", "content", savedCount, copiedCount);
+        return instanceForTest(id.getAndIncrement(), TemplateCategory.THANK, "후배", "content", savedCount, copiedCount);
     }
 
     public static Template 감사전하기() {

--- a/src/test/java/com/baro/template/fixture/TemplateFixture.java
+++ b/src/test/java/com/baro/template/fixture/TemplateFixture.java
@@ -2,13 +2,13 @@ package com.baro.template.fixture;
 
 import static com.baro.template.domain.Template.instanceForTest;
 
-import com.baro.template.domain.Category;
 import com.baro.template.domain.Template;
+import com.baro.template.domain.TemplateCategory;
 
 public class TemplateFixture {
 
     public static Template 보고하기(int savedCount, int copiedCount) {
-        return instanceForTest(Category.REPORT, "상사", "content", savedCount, copiedCount);
+        return instanceForTest(TemplateCategory.REPORT, "상사", "content", savedCount, copiedCount);
     }
 
     public static Template 보고하기() {
@@ -16,7 +16,7 @@ public class TemplateFixture {
     }
 
     public static Template 감사전하기(int savedCount, int copiedCount) {
-        return instanceForTest(Category.THANK, "후배", "content", savedCount, copiedCount);
+        return instanceForTest(TemplateCategory.THANK, "후배", "content", savedCount, copiedCount);
     }
 
     public static Template 감사전하기() {

--- a/src/test/java/com/baro/template/presentation/SortTypeTest.java
+++ b/src/test/java/com/baro/template/presentation/SortTypeTest.java
@@ -1,0 +1,41 @@
+package com.baro.template.presentation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.baro.template.domain.Template;
+import com.baro.template.exception.SortException;
+import com.baro.template.exception.SortExceptionType;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Sort;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class SortTypeTest {
+
+    @Test
+    void 해당하는_정렬_타입을_반환한다() {
+        // given
+        var sortType = "new";
+
+        // when
+        var result = SortType.getSort(sortType);
+
+        // then
+        assertThat(result).isEqualTo(Sort.TypedSort.sort(Template.class).by(Template::getCreatedAt).descending());
+    }
+
+    @Test
+    void 해당하는_정렬_타입이_없을_경우_예외를_반환한다() {
+        // given
+        var sortType = "nothing";
+
+        // when & then
+        assertThatThrownBy(() -> SortType.getSort(sortType))
+                .isInstanceOf(SortException.class)
+                .extracting("exceptionType")
+                .isEqualTo(SortExceptionType.INVALID_SORT_TYPE);
+    }
+}

--- a/src/test/java/com/baro/template/presentation/TemplateApiTest.java
+++ b/src/test/java/com/baro/template/presentation/TemplateApiTest.java
@@ -26,9 +26,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 @SuppressWarnings("NonAsciiCharacters")
 class TemplateApiTest extends RestApiTest {
 
+    private final String rootPath = "";
     @Autowired
     private TemplateRepository templateRepository;
-    private final String rootPath = "";
 
     @Test
     void 특정_카테고리의_템플릿을_조회한다() {

--- a/src/test/java/com/baro/template/presentation/TemplateApiTest.java
+++ b/src/test/java/com/baro/template/presentation/TemplateApiTest.java
@@ -1,0 +1,94 @@
+package com.baro.template.presentation;
+
+import static com.baro.auth.fixture.OAuthMemberInfoFixture.동균;
+import static com.baro.auth.fixture.OAuthMemberInfoFixture.유빈;
+import static com.baro.common.acceptance.AcceptanceSteps.성공;
+import static com.baro.common.acceptance.AcceptanceSteps.응답값_없음;
+import static com.baro.common.acceptance.AcceptanceSteps.응답값을_검증한다;
+import static com.baro.common.acceptance.AcceptanceSteps.응답의_개수를_검증한다;
+import static com.baro.common.acceptance.AcceptanceSteps.잘못된_요청;
+import static com.baro.common.acceptance.template.TemplateAcceptanceSteps.템플릿_조회_요청_성공;
+import static com.baro.common.acceptance.template.TemplateAcceptanceSteps.템플릿_조회_요청_실패;
+import static com.baro.common.acceptance.template.TemplateAcceptanceSteps.템플릿_조회시_응답값이_없는_요청;
+import static com.baro.template.fixture.TemplateFixture.감사전하기;
+import static com.baro.template.fixture.TemplateFixture.보고하기;
+
+import com.baro.common.RestApiTest;
+import com.baro.template.domain.Template;
+import com.baro.template.domain.TemplateRepository;
+import java.util.List;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class TemplateApiTest extends RestApiTest {
+
+    @Autowired
+    private TemplateRepository templateRepository;
+    private final String rootPath = "";
+
+    @Test
+    void 특정_카테고리의_템플릿을_조회한다() {
+        // given
+        var 카테고리 = "report";
+        var 정렬 = "new";
+        var 토큰 = 로그인(유빈());
+        템플릿_데이터_준비(List.of(보고하기(), 보고하기(), 보고하기(), 감사전하기()));
+
+        // when
+        var 응답 = 템플릿_조회_요청_성공(토큰, 카테고리, 정렬);
+
+        // then
+        응답값을_검증한다(응답, 성공);
+        응답의_개수를_검증한다(응답, rootPath, 3);
+    }
+
+    @Test
+    void 존재하지_않는_카테고리_조회시_예외를_반환한다() {
+        // given
+        var 카테고리 = "nothing";
+        var 정렬 = "new";
+        var 토큰 = 로그인(동균());
+
+        // when
+        var 응답 = 템플릿_조회_요청_실패(토큰, 카테고리, 정렬);
+
+        // then
+        응답값을_검증한다(응답, 잘못된_요청);
+    }
+
+    @Test
+    void 존재하지_않는_정렬로_조회시_예외를_반환한다() {
+        // given
+        var 카테고리 = "report";
+        var 정렬 = "view";
+        var 토큰 = 로그인(동균());
+
+        // when
+        var 응답 = 템플릿_조회_요청_실패(토큰, 카테고리, 정렬);
+
+        // then
+        응답값을_검증한다(응답, 잘못된_요청);
+    }
+
+    @Test
+    void 템플릿이_존재하지_않는_경우_반환하는_응답이_없다() {
+        // given
+        var 카테고리 = "report";
+        var 정렬 = "new";
+        var 토큰 = 로그인(동균());
+
+        // when
+        var 응답 = 템플릿_조회시_응답값이_없는_요청(토큰, 카테고리, 정렬);
+
+        // then
+        응답값을_검증한다(응답, 응답값_없음);
+    }
+
+    private void 템플릿_데이터_준비(List<Template> templates) {
+        templates.forEach(templateRepository::save);
+    }
+}

--- a/src/test/java/com/baro/template/presentation/TemplateApiTest.java
+++ b/src/test/java/com/baro/template/presentation/TemplateApiTest.java
@@ -3,7 +3,6 @@ package com.baro.template.presentation;
 import static com.baro.auth.fixture.OAuthMemberInfoFixture.동균;
 import static com.baro.auth.fixture.OAuthMemberInfoFixture.유빈;
 import static com.baro.common.acceptance.AcceptanceSteps.성공;
-import static com.baro.common.acceptance.AcceptanceSteps.응답값_없음;
 import static com.baro.common.acceptance.AcceptanceSteps.응답값을_검증한다;
 import static com.baro.common.acceptance.AcceptanceSteps.응답의_개수를_검증한다;
 import static com.baro.common.acceptance.AcceptanceSteps.잘못된_요청;
@@ -85,7 +84,8 @@ class TemplateApiTest extends RestApiTest {
         var 응답 = 템플릿_조회시_응답값이_없는_요청(토큰, 카테고리, 정렬);
 
         // then
-        응답값을_검증한다(응답, 응답값_없음);
+        응답값을_검증한다(응답, 성공);
+        응답의_개수를_검증한다(응답, rootPath, 0);
     }
 
     private void 템플릿_데이터_준비(List<Template> templates) {

--- a/src/test/java/com/baro/template/presentation/TemplateApiTest.java
+++ b/src/test/java/com/baro/template/presentation/TemplateApiTest.java
@@ -5,6 +5,7 @@ import static com.baro.auth.fixture.OAuthMemberInfoFixture.유빈;
 import static com.baro.common.acceptance.AcceptanceSteps.성공;
 import static com.baro.common.acceptance.AcceptanceSteps.응답값을_검증한다;
 import static com.baro.common.acceptance.AcceptanceSteps.응답의_개수를_검증한다;
+import static com.baro.common.acceptance.AcceptanceSteps.응답의_특정_필드값을_검증한다;
 import static com.baro.common.acceptance.AcceptanceSteps.잘못된_요청;
 import static com.baro.common.acceptance.template.TemplateAcceptanceSteps.템플릿_조회_요청_성공;
 import static com.baro.common.acceptance.template.TemplateAcceptanceSteps.템플릿_조회_요청_실패;
@@ -25,7 +26,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 @SuppressWarnings("NonAsciiCharacters")
 class TemplateApiTest extends RestApiTest {
 
-    private final String rootPath = "";
     @Autowired
     private TemplateRepository templateRepository;
 
@@ -42,7 +42,7 @@ class TemplateApiTest extends RestApiTest {
 
         // then
         응답값을_검증한다(응답, 성공);
-        응답의_개수를_검증한다(응답, rootPath, 3);
+        응답의_개수를_검증한다(응답, "content", 3);
     }
 
     @Test
@@ -85,7 +85,8 @@ class TemplateApiTest extends RestApiTest {
 
         // then
         응답값을_검증한다(응답, 성공);
-        응답의_개수를_검증한다(응답, rootPath, 0);
+        응답의_개수를_검증한다(응답, "content", 0);
+        응답의_특정_필드값을_검증한다(응답, "empty", "true");
     }
 
     private void 템플릿_데이터_준비(List<Template> templates) {


### PR DESCRIPTION
## 관련된 이슈
<!-- 관련있는 이슈 번호(#000) 기입
merge를 기대하는 경우, close와 함께 기입-->
BAR-210

## 작업 사항
<!-- 구현한 내용에 대한 설명-->
- 인수테스트시 응답의 개수를 검증하는 메서드를 추가하였습니다.
- 카테고리와 정렬을 enum화 하여, enum 내부에서 해당하는 요청 타입이 없을경우 예외를 던지도록 구현하였습니다.
- 템플릿 불러오기 api 구현
- 페이지네이션으로 미리 구현해놓았습니다
- Sort의 property를 스트링으로 관리하는 것을 피하고자 TypedSort를 사용하였습니다.
- 엔티티 컬럼 변경으로 인해 새로운 flyway v4를 생성하였습니다 ([submodule commit](https://github.com/shinyubin989/sub-module/commit/3b944bd1106395cc70fbc664d635d0d3aab7426b))

## 기타
- 테스트에서만 사용하는 생성자가 필요해서, instanceForTest라는 네이밍의 팩토리메서드를 생성해보았습니다