### PR TITLE
feat: 맞춤법 검사 결과 반영

### DIFF
--- a/src/main/java/com/baro/memo/application/TemporalMemoService.java
+++ b/src/main/java/com/baro/memo/application/TemporalMemoService.java
@@ -3,6 +3,7 @@ package com.baro.memo.application;
 
 import com.baro.member.domain.Member;
 import com.baro.member.domain.MemberRepository;
+import com.baro.memo.application.dto.ApplyCorrectionCommand;
 import com.baro.memo.application.dto.ArchiveTemporalMemoCommand;
 import com.baro.memo.application.dto.ArchiveTemporalMemoResult;
 import com.baro.memo.application.dto.DeleteTemporalMemoCommand;
@@ -58,5 +59,11 @@ public class TemporalMemoService {
         TemporalMemo temporalMemo = temporalMemoRepository.getById(command.temporalMemoId());
         temporalMemo.matchOwner(command.memberId());
         temporalMemoRepository.delete(temporalMemo);
+    }
+
+    public void applyCorrection(ApplyCorrectionCommand command) {
+        TemporalMemo temporalMemo = temporalMemoRepository.getById(command.temporalMemoId());
+        temporalMemo.matchOwner(command.memberId());
+        temporalMemo.applyCorrection(MemoContent.from(command.contents()));
     }
 }

--- a/src/main/java/com/baro/memo/application/dto/ApplyCorrectionCommand.java
+++ b/src/main/java/com/baro/memo/application/dto/ApplyCorrectionCommand.java
@@ -1,0 +1,8 @@
+package com.baro.memo.application.dto;
+
+public record ApplyCorrectionCommand(
+        Long memberId,
+        Long temporalMemoId,
+        String contents
+) {
+}

--- a/src/main/java/com/baro/memo/domain/MemoContent.java
+++ b/src/main/java/com/baro/memo/domain/MemoContent.java
@@ -16,7 +16,7 @@ public class MemoContent {
 
     private static final int MAX_CONTENT_SIZE = 500;
 
-    @Column(length = MAX_CONTENT_SIZE)
+    @Column(length = 1024)
     private String content;
 
     private MemoContent(String content) {

--- a/src/main/java/com/baro/memo/domain/TemporalMemo.java
+++ b/src/main/java/com/baro/memo/domain/TemporalMemo.java
@@ -87,4 +87,11 @@ public class TemporalMemo extends BaseEntity {
     public void archivedAsMemo(Memo memo) {
         this.memo = memo;
     }
+
+    public void applyCorrection(MemoContent correctionContent) {
+        if (isCorrected()) {
+            throw new TemporalMemoException(TemporalMemoExceptionType.ALREADY_CORRECTED);
+        }
+        this.correctionContent = correctionContent;
+    }
 }

--- a/src/main/java/com/baro/memo/exception/TemporalMemoExceptionType.java
+++ b/src/main/java/com/baro/memo/exception/TemporalMemoExceptionType.java
@@ -9,6 +9,7 @@ public enum TemporalMemoExceptionType implements RequestExceptionType {
 
     NOT_EXIST_TEMPORAL_MEMO("TM02", "존재하지 않는 끄적이는 메모 입니다.", HttpStatus.NOT_FOUND),
     NOT_MATCH_OWNER("TM03", "끄적이는 메모에 대한 접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
+    ALREADY_CORRECTED("TO04", "이미 맞춤법 검사가 완료된 끄적이는 메모 입니다.", HttpStatus.BAD_REQUEST),
     ;
 
     private final String errorCode;

--- a/src/main/java/com/baro/memo/presentation/TemporalMemoController.java
+++ b/src/main/java/com/baro/memo/presentation/TemporalMemoController.java
@@ -3,12 +3,14 @@ package com.baro.memo.presentation;
 
 import com.baro.auth.domain.AuthMember;
 import com.baro.memo.application.TemporalMemoService;
+import com.baro.memo.application.dto.ApplyCorrectionCommand;
 import com.baro.memo.application.dto.ArchiveTemporalMemoCommand;
 import com.baro.memo.application.dto.ArchiveTemporalMemoResult;
 import com.baro.memo.application.dto.DeleteTemporalMemoCommand;
 import com.baro.memo.application.dto.SaveTemporalMemoCommand;
 import com.baro.memo.application.dto.SaveTemporalMemoResult;
 import com.baro.memo.application.dto.UpdateTemporalMemoCommand;
+import com.baro.memo.presentation.dto.ApplyCorrectionRequest;
 import com.baro.memo.presentation.dto.ArchiveTemporalMemoRequest;
 import com.baro.memo.presentation.dto.SaveTemporalMemoRequest;
 import com.baro.memo.presentation.dto.UpdateTemporalMemoRequest;
@@ -79,6 +81,18 @@ public class TemporalMemoController {
     ) {
         DeleteTemporalMemoCommand command = new DeleteTemporalMemoCommand(authMember.id(), temporalMemoId);
         temporalMemoService.deleteTemporalMemo(command);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping("/{temporalMemoId}/correction")
+    public ResponseEntity<Void> applyCorrection(
+            AuthMember authMember,
+            @RequestBody ApplyCorrectionRequest request,
+            @PathVariable Long temporalMemoId
+    ) {
+        ApplyCorrectionCommand command = new ApplyCorrectionCommand(authMember.id(), temporalMemoId,
+                request.content());
+        temporalMemoService.applyCorrection(command);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/baro/memo/presentation/dto/ApplyCorrectionRequest.java
+++ b/src/main/java/com/baro/memo/presentation/dto/ApplyCorrectionRequest.java
@@ -1,0 +1,6 @@
+package com.baro.memo.presentation.dto;
+
+public record ApplyCorrectionRequest(
+        String content
+) {
+}

--- a/src/test/java/com/baro/common/acceptance/memo/TemporalMemoAcceptanceSteps.java
+++ b/src/test/java/com/baro/common/acceptance/memo/TemporalMemoAcceptanceSteps.java
@@ -14,6 +14,7 @@ import static org.springframework.restdocs.request.RequestDocumentation.paramete
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 
 import com.baro.auth.domain.Token;
+import com.baro.memo.presentation.dto.ApplyCorrectionRequest;
 import com.baro.memo.presentation.dto.ArchiveTemporalMemoRequest;
 import com.baro.memo.presentation.dto.SaveTemporalMemoRequest;
 import com.baro.memo.presentation.dto.UpdateTemporalMemoRequest;
@@ -30,6 +31,8 @@ public class TemporalMemoAcceptanceSteps {
     public static final SaveTemporalMemoRequest 크기_초과_끄적이는_메모_작성_바디 = new SaveTemporalMemoRequest(크기_초과_컨텐츠);
     public static final UpdateTemporalMemoRequest 끄적이는_메모_수정_바디 = new UpdateTemporalMemoRequest("끄적이는 메모 수정 컨텐츠");
     public static final UpdateTemporalMemoRequest 크기_초과_끄적이는_메모_수정_바디 = new UpdateTemporalMemoRequest(크기_초과_컨텐츠);
+    public static final ApplyCorrectionRequest 맞춤법_검사_결과_반영_바디 = new ApplyCorrectionRequest("맞춤법 검사 결과");
+    public static final ApplyCorrectionRequest 크기_초과_맞춤법_검사_결과_반영_바디 = new ApplyCorrectionRequest(크기_초과_컨텐츠);
 
     public static ArchiveTemporalMemoRequest 메모_아카이브_요청_바디(Long 메모_폴더_ID) {
         return new ArchiveTemporalMemoRequest(메모_폴더_ID);
@@ -193,6 +196,47 @@ public class TemporalMemoAcceptanceSteps {
                 ).contentType(MediaType.APPLICATION_JSON_VALUE)
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + 토큰.accessToken())
                 .when().delete("/temporal-memos/{temporalMemoId}", 끄적이는_메모_ID)
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 끄적이는_메모_맞춤법_검사_결과_반영_요청(Token 토큰, Long 끄적이는_메모_ID,
+                                                                        ApplyCorrectionRequest 바디) {
+        return RestAssured.given(requestSpec).log().all()
+                .filter(document(DEFAULT_REST_DOCS_PATH,
+                        pathParameters(
+                                parameterWithName("temporalMemoId").description("끄적이는 메모 ID")
+                        ),
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("인증 토큰")
+                        ),
+                        requestFields(
+                                fieldWithPath("content").description("맞춤법 검사 결과")
+                        ))
+                ).contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + 토큰.accessToken()).body(바디)
+                .when().patch("/temporal-memos/{temporalMemoId}/correction", 끄적이는_메모_ID)
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 잘못된_끄적이는_메모_맞춤법_검사_결과_반영_요청(Token 토큰, Long 끄적이는_메모_ID,
+                                                                            ApplyCorrectionRequest 바디) {
+        return RestAssured.given(requestSpec).log().all()
+                .filter(document(DEFAULT_REST_DOCS_PATH,
+                        pathParameters(
+                                parameterWithName("temporalMemoId").description("끄적이는 메모 ID")
+                        ),
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("인증 토큰")
+                        ),
+                        requestFields(
+                                fieldWithPath("content").description("맞춤법 검사 결과")
+                        ),
+                        responseFields(예외_응답()))
+                ).contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + 토큰.accessToken()).body(바디)
+                .when().patch("/temporal-memos/{temporalMemoId}/correction", 끄적이는_메모_ID)
                 .then().log().all()
                 .extract();
     }

--- a/src/test/java/com/baro/memo/application/TemporalMemoServiceTest.java
+++ b/src/test/java/com/baro/memo/application/TemporalMemoServiceTest.java
@@ -276,8 +276,11 @@ class TemporalMemoServiceTest {
 
         // then
         TemporalMemo updatedTemporalMemo = temporalMemoRepository.getById(temporalMemo.getId());
-        assertThat(updatedTemporalMemo.isCorrected()).isTrue();
-        assertThat(updatedTemporalMemo.getCorrectionContent()).isEqualTo(MemoContent.from(correctionContent));
+        assertAll(
+                () -> assertThat(updatedTemporalMemo.isCorrected()).isTrue(),
+                () -> assertThat(updatedTemporalMemo.getCorrectionContent()).isEqualTo(
+                        MemoContent.from(correctionContent))
+        );
     }
 
     @Test

--- a/src/test/java/com/baro/memo/application/TemporalMemoServiceTest.java
+++ b/src/test/java/com/baro/memo/application/TemporalMemoServiceTest.java
@@ -8,6 +8,7 @@ import com.baro.member.domain.Member;
 import com.baro.member.domain.MemberRepository;
 import com.baro.member.fake.FakeMemberRepository;
 import com.baro.member.fixture.MemberFixture;
+import com.baro.memo.application.dto.ApplyCorrectionCommand;
 import com.baro.memo.application.dto.ArchiveTemporalMemoCommand;
 import com.baro.memo.application.dto.DeleteTemporalMemoCommand;
 import com.baro.memo.application.dto.SaveTemporalMemoCommand;
@@ -259,5 +260,73 @@ class TemporalMemoServiceTest {
                 .isInstanceOf(TemporalMemoException.class)
                 .extracting("exceptionType")
                 .isEqualTo(TemporalMemoExceptionType.NOT_EXIST_TEMPORAL_MEMO);
+    }
+
+    @Test
+    void 끄적이는_메모_맞춤법_검사_결과_반영() {
+        // given
+        Member member = memberRepository.save(MemberFixture.memberWithNickname("nickname1"));
+        TemporalMemo temporalMemo = temporalMemoRepository.save(TemporalMemo.of(member, "testContent"));
+        String correctionContent = "correctedContent";
+        ApplyCorrectionCommand command = new ApplyCorrectionCommand(member.getId(), temporalMemo.getId(),
+                correctionContent);
+
+        // when
+        temporalMemoService.applyCorrection(command);
+
+        // then
+        TemporalMemo updatedTemporalMemo = temporalMemoRepository.getById(temporalMemo.getId());
+        assertThat(updatedTemporalMemo.isCorrected()).isTrue();
+        assertThat(updatedTemporalMemo.getCorrectionContent()).isEqualTo(MemoContent.from(correctionContent));
+    }
+
+    @Test
+    void 다른_사람의_끄적이는_메모_맞춤법_검사_결과_반영시_예외_발생() {
+        // given
+        Member member = memberRepository.save(MemberFixture.memberWithNickname("nickname1"));
+        Member otherMember = memberRepository.save(MemberFixture.memberWithNickname("nickname2"));
+        TemporalMemo temporalMemo = temporalMemoRepository.save(TemporalMemo.of(member, "testContent"));
+        String correctionContent = "correctedContent";
+        ApplyCorrectionCommand command = new ApplyCorrectionCommand(otherMember.getId(), temporalMemo.getId(),
+                correctionContent);
+
+        // when & then
+        assertThatThrownBy(() -> temporalMemoService.applyCorrection(command))
+                .isInstanceOf(TemporalMemoException.class)
+                .extracting("exceptionType")
+                .isEqualTo(TemporalMemoExceptionType.NOT_MATCH_OWNER);
+    }
+
+    @Test
+    void 존재하지_않는_끄적이는_메모_맞춤법_검사_결과_반영시_예외_발생() {
+        // given
+        Member member = memberRepository.save(MemberFixture.memberWithNickname("nickname1"));
+        Long notExistTemporalMemoId = 999L;
+        String correctionContent = "correctedContent";
+        ApplyCorrectionCommand command = new ApplyCorrectionCommand(member.getId(), notExistTemporalMemoId,
+                correctionContent);
+
+        // when & then
+        assertThatThrownBy(() -> temporalMemoService.applyCorrection(command))
+                .isInstanceOf(TemporalMemoException.class)
+                .extracting("exceptionType")
+                .isEqualTo(TemporalMemoExceptionType.NOT_EXIST_TEMPORAL_MEMO);
+    }
+
+    @Test
+    void 이미_맞춤법_검사가_완료된_끄적이는_메모_맞춤법_검사_결과_반영시_예외_발생() {
+        // given
+        Member member = memberRepository.save(MemberFixture.memberWithNickname("nickname1"));
+        TemporalMemo temporalMemo = temporalMemoRepository.save(TemporalMemo.of(member, "testContent"));
+        temporalMemo.applyCorrection(MemoContent.from("correctedContent"));
+        String correctionContent = "correctedContent";
+        ApplyCorrectionCommand command = new ApplyCorrectionCommand(member.getId(), temporalMemo.getId(),
+                correctionContent);
+
+        // when & then
+        assertThatThrownBy(() -> temporalMemoService.applyCorrection(command))
+                .isInstanceOf(TemporalMemoException.class)
+                .extracting("exceptionType")
+                .isEqualTo(TemporalMemoExceptionType.ALREADY_CORRECTED);
     }
 }

--- a/src/test/java/com/baro/memo/domain/TemporalMemoTest.java
+++ b/src/test/java/com/baro/memo/domain/TemporalMemoTest.java
@@ -2,6 +2,7 @@ package com.baro.memo.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.baro.member.domain.Member;
 import com.baro.member.fixture.MemberFixture;
@@ -99,5 +100,35 @@ class TemporalMemoTest {
 
         // then
         assertThat(isCorrected).isFalse();
+    }
+
+    @Test
+    void 끄적이는_메모의_맞춤법_검사_결과를_반영한다() {
+        // given
+        TemporalMemo temporalMemo = TemporalMemo.of(MemberFixture.memberWithNickname("바로"), "메모");
+        MemoContent correctionContent = MemoContent.from("메모");
+
+        // when
+        temporalMemo.applyCorrection(correctionContent);
+
+        // then
+        assertAll(
+                () -> assertThat(temporalMemo.getCorrectionContent()).isEqualTo(correctionContent),
+                () -> assertThat(temporalMemo.isCorrected()).isTrue()
+        );
+    }
+
+    @Test
+    void 이미_맞춤법_검사_결과가_반영된_끄적이는_메모에_결과_반영시_예외를_반환한다() {
+        // given
+        TemporalMemo temporalMemo = TemporalMemo.of(MemberFixture.memberWithNickname("바로"), "메모");
+        MemoContent correctionContent = MemoContent.from("메모");
+        temporalMemo.applyCorrection(correctionContent);
+
+        // when & then
+        assertThatCode(() -> temporalMemo.applyCorrection(correctionContent))
+                .isInstanceOf(TemporalMemoException.class)
+                .extracting("exceptionType")
+                .isEqualTo(TemporalMemoExceptionType.ALREADY_CORRECTED);
     }
 }

--- a/src/test/java/com/baro/memo/presentation/TemproalMemoApiTest.java
+++ b/src/test/java/com/baro/memo/presentation/TemproalMemoApiTest.java
@@ -2,6 +2,7 @@ package com.baro.memo.presentation;
 
 import static com.baro.auth.fixture.OAuthMemberInfoFixture.아현;
 import static com.baro.auth.fixture.OAuthMemberInfoFixture.유빈;
+import static com.baro.auth.fixture.OAuthMemberInfoFixture.준희;
 import static com.baro.auth.fixture.OAuthMemberInfoFixture.태연;
 import static com.baro.common.acceptance.AcceptanceSteps.권한_없음;
 import static com.baro.common.acceptance.AcceptanceSteps.생성됨;
@@ -10,6 +11,7 @@ import static com.baro.common.acceptance.AcceptanceSteps.응답값을_검증한�
 import static com.baro.common.acceptance.AcceptanceSteps.응답의_Location_헤더가_존재한다;
 import static com.baro.common.acceptance.AcceptanceSteps.잘못된_요청;
 import static com.baro.common.acceptance.AcceptanceSteps.존재하지_않음;
+import static com.baro.common.acceptance.memo.TemporalMemoAcceptanceSteps.끄적이는_메모_맞춤법_검사_결과_반영_요청;
 import static com.baro.common.acceptance.memo.TemporalMemoAcceptanceSteps.끄적이는_메모_바디;
 import static com.baro.common.acceptance.memo.TemporalMemoAcceptanceSteps.끄적이는_메모_수정_바디;
 import static com.baro.common.acceptance.memo.TemporalMemoAcceptanceSteps.끄적이는메모_삭제_요청;
@@ -17,13 +19,16 @@ import static com.baro.common.acceptance.memo.TemporalMemoAcceptanceSteps.끄적
 import static com.baro.common.acceptance.memo.TemporalMemoAcceptanceSteps.끄적이는메모_수정_요청;
 import static com.baro.common.acceptance.memo.TemporalMemoAcceptanceSteps.끄적이는메모_아카이빙_요청;
 import static com.baro.common.acceptance.memo.TemporalMemoAcceptanceSteps.끄적이는메모를_생성하고_ID를_반환한다;
+import static com.baro.common.acceptance.memo.TemporalMemoAcceptanceSteps.맞춤법_검사_결과_반영_바디;
 import static com.baro.common.acceptance.memo.TemporalMemoAcceptanceSteps.메모_아카이브_요청_바디;
+import static com.baro.common.acceptance.memo.TemporalMemoAcceptanceSteps.잘못된_끄적이는_메모_맞춤법_검사_결과_반영_요청;
 import static com.baro.common.acceptance.memo.TemporalMemoAcceptanceSteps.잘못된_끄적이는_메모_생성_요청;
 import static com.baro.common.acceptance.memo.TemporalMemoAcceptanceSteps.잘못된_끄적이는메모_삭제_요청;
 import static com.baro.common.acceptance.memo.TemporalMemoAcceptanceSteps.잘못된_끄적이는메모_수정_요청;
 import static com.baro.common.acceptance.memo.TemporalMemoAcceptanceSteps.잘못된_끄적이는메모_아카이빙_요청;
 import static com.baro.common.acceptance.memo.TemporalMemoAcceptanceSteps.크기_초과_끄적이는_메모_수정_바디;
 import static com.baro.common.acceptance.memo.TemporalMemoAcceptanceSteps.크기_초과_끄적이는_메모_작성_바디;
+import static com.baro.common.acceptance.memo.TemporalMemoAcceptanceSteps.크기_초과_맞춤법_검사_결과_반영_바디;
 import static com.baro.common.acceptance.memofolder.MemoFolderAcceptanceSteps.메모_폴더를_생성_하고_ID를_반환한다;
 import static com.baro.common.acceptance.memofolder.MemoFolderAcceptanceSteps.폴더_이름_바디;
 
@@ -226,5 +231,73 @@ public class TemproalMemoApiTest extends RestApiTest {
 
         // then
         응답값을_검증한다(응답, 존재하지_않음);
+    }
+
+    @Test
+    void 끄적이는_메모의_맞춤법_검사_결과를_반영_한다() {
+        // given
+        var 준희 = 로그인(준희());
+        var 준희의_끄적이는_메모_ID = 끄적이는메모를_생성하고_ID를_반환한다(준희, 끄적이는_메모_바디);
+
+        // when
+        var 응답 = 끄적이는_메모_맞춤법_검사_결과_반영_요청(준희, 준희의_끄적이는_메모_ID, 맞춤법_검사_결과_반영_바디);
+
+        // then
+        응답값을_검증한다(응답, 응답값_없음);
+    }
+
+    @Test
+    void 다른_사람의_끄적이는_메모의_맞춤법_검사_결과를_반영_시_예외를_반환한다() {
+        // given
+        var 준희 = 로그인(준희());
+        var 준희의_끄적이는_메모_ID = 끄적이는메모를_생성하고_ID를_반환한다(준희, 끄적이는_메모_바디);
+
+        var 태연 = 로그인(태연());
+
+        // when
+        var 응답 = 잘못된_끄적이는_메모_맞춤법_검사_결과_반영_요청(태연, 준희의_끄적이는_메모_ID, 맞춤법_검사_결과_반영_바디);
+
+        // then
+        응답값을_검증한다(응답, 권한_없음);
+    }
+
+    @Test
+    void 존재_하지_않는_끄적이는_메모의_맞춤법_검사_결과를_반영_시_예외를_반환한다() {
+        // given
+        var 준희 = 로그인(준희());
+        var 존재_하지_않는_끄적이는_메모_ID = 999L;
+
+        // when
+        var 응답 = 잘못된_끄적이는_메모_맞춤법_검사_결과_반영_요청(준희, 존재_하지_않는_끄적이는_메모_ID, 맞춤법_검사_결과_반영_바디);
+
+        // then
+        응답값을_검증한다(응답, 존재하지_않음);
+    }
+
+    @Test
+    void 최대_길이를_초과하는_맞춤법_검사_결과를_반영_시_예외를_반환한다() {
+        // given
+        var 준희 = 로그인(준희());
+        var 준희의_끄적이는_메모_ID = 끄적이는메모를_생성하고_ID를_반환한다(준희, 끄적이는_메모_바디);
+
+        // when
+        var 응답 = 잘못된_끄적이는_메모_맞춤법_검사_결과_반영_요청(준희, 준희의_끄적이는_메모_ID, 크기_초과_맞춤법_검사_결과_반영_바디);
+
+        // then
+        응답값을_검증한다(응답, 잘못된_요청);
+    }
+
+    @Test
+    void 이미_맞춤법_검사_결과가_존재하는_끄적이는_메모에_결과_반영_시_예외를_반환한다() {
+        // given
+        var 준희 = 로그인(준희());
+        var 준희의_끄적이는_메모_ID = 끄적이는메모를_생성하고_ID를_반환한다(준희, 끄적이는_메모_바디);
+        끄적이는_메모_맞춤법_검사_결과_반영_요청(준희, 준희의_끄적이는_메모_ID, 맞춤법_검사_결과_반영_바디);
+
+        // when
+        var 응답 = 잘못된_끄적이는_메모_맞춤법_검사_결과_반영_요청(준희, 준희의_끄적이는_메모_ID, 맞춤법_검사_결과_반영_바디);
+
+        // then
+        응답값을_검증한다(응답, 잘못된_요청);
     }
 }


### PR DESCRIPTION
## 관련된 이슈
BAR-214

## 작업 사항
- 맞춤법 검사 결과를 반영하는 API 추가
- 권한, 자원 존재 유무, 검사 결과 길이 검증
- 이미 맞춤법 검사가 완료된 끄적이는 메모에 검사 결과 반영 요청 시 예외가 발생하도록 하였습니다.


## 기타
- on #39
