### PR TITLE
feat: 끄적이는 메모 조회 api

### DIFF
--- a/src/main/java/com/baro/common/entity/BaseEntity.java
+++ b/src/main/java/com/baro/common/entity/BaseEntity.java
@@ -18,4 +18,8 @@ public class BaseEntity {
 
     @LastModifiedDate
     protected LocalDateTime updatedAt;
+
+    public void setCreatedAtForTest(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
 }

--- a/src/main/java/com/baro/common/exception/CommonRequestExceptionType.java
+++ b/src/main/java/com/baro/common/exception/CommonRequestExceptionType.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 public enum CommonRequestExceptionType implements RequestExceptionType {
 
     MISSING_PARAMETER_EXCEPTION("CM01", "Request parameter is empty", HttpStatus.BAD_REQUEST),
+    INVALID_TYPE_REQUEST_EXCEPTION("CM02", "Request type is invalid", HttpStatus.BAD_REQUEST),
     ;
 
     private final String errorCode;

--- a/src/main/java/com/baro/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/baro/common/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.baro.common.exception;
 
+import static com.baro.common.exception.CommonRequestExceptionType.INVALID_TYPE_REQUEST_EXCEPTION;
 import static com.baro.common.exception.CommonRequestExceptionType.MISSING_PARAMETER_EXCEPTION;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -9,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 @Slf4j
@@ -36,6 +38,14 @@ class GlobalExceptionHandler {
         log.warn("[handleRequestException throw MissingServletRequestParameterException : {}", e.getMessage());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(RequestExceptionResponse.from(MISSING_PARAMETER_EXCEPTION));
+    }
+
+    @ExceptionHandler(value = {MethodArgumentTypeMismatchException.class})
+    public ResponseEntity<RequestExceptionResponse> handleMissingRequestParameters(
+            MethodArgumentTypeMismatchException e) {
+        log.warn("[handleRequestException throw MissingServletRequestParameterException : {}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(RequestExceptionResponse.from(INVALID_TYPE_REQUEST_EXCEPTION));
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/baro/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/baro/common/exception/GlobalExceptionHandler.java
@@ -41,9 +41,9 @@ class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(value = {MethodArgumentTypeMismatchException.class})
-    public ResponseEntity<RequestExceptionResponse> handleMissingRequestParameters(
+    public ResponseEntity<RequestExceptionResponse> handleMethodArgumentTypeMismatchException(
             MethodArgumentTypeMismatchException e) {
-        log.warn("[handleRequestException throw MissingServletRequestParameterException : {}", e.getMessage());
+        log.warn("[handleRequestException throw MethodArgumentTypeMismatchException : {}", e.getMessage());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(RequestExceptionResponse.from(INVALID_TYPE_REQUEST_EXCEPTION));
     }

--- a/src/main/java/com/baro/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/baro/common/exception/GlobalExceptionHandler.java
@@ -1,9 +1,12 @@
 package com.baro.common.exception;
 
+import static com.baro.common.exception.CommonRequestExceptionType.MISSING_PARAMETER_EXCEPTION;
+
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
@@ -25,6 +28,14 @@ class GlobalExceptionHandler {
         log.warn("[handleRequestException throw MaxUploadSizeExceededException : {}", e.getMessage());
         return ResponseEntity.status(HttpStatus.PAYLOAD_TOO_LARGE)
                 .body("File size limit exceeded");
+    }
+
+    @ExceptionHandler(value = {MissingServletRequestParameterException.class})
+    public ResponseEntity<RequestExceptionResponse> handleMissingRequestParameters(
+            MissingServletRequestParameterException e) {
+        log.warn("[handleRequestException throw MissingServletRequestParameterException : {}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(RequestExceptionResponse.from(MISSING_PARAMETER_EXCEPTION));
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/baro/memo/application/TemporalMemoService.java
+++ b/src/main/java/com/baro/memo/application/TemporalMemoService.java
@@ -86,9 +86,9 @@ public class TemporalMemoService {
 
         return temporalMemosByDate.keySet().stream()
                 .sorted(Comparator.reverseOrder())
-                .map(createdAt -> new FindTemporalMemoHistoriesResult(createdAt,
-                        toTemporalMemoResults(temporalMemosByDate.get(createdAt))
-                ))
+                .map(createdAt -> new FindTemporalMemoHistoriesResult(
+                        createdAt, toTemporalMemoResults(temporalMemosByDate.get(createdAt)
+                )))
                 .toList();
     }
 
@@ -107,7 +107,7 @@ public class TemporalMemoService {
     private List<FindTemporalMemoResult> toTemporalMemoResults(List<TemporalMemo> temporalMemos) {
         return temporalMemos.stream()
                 .map(FindTemporalMemoResult::from)
-//                .sorted(Comparator.comparing(FindTemporalMemoResult::createdAt).reversed()) FIXME: 회의후 정렬기준 반영
+                .sorted(Comparator.comparing(FindTemporalMemoResult::createdAt))
                 .toList();
     }
 }

--- a/src/main/java/com/baro/memo/application/TemporalMemoService.java
+++ b/src/main/java/com/baro/memo/application/TemporalMemoService.java
@@ -23,6 +23,7 @@ import com.baro.memo.exception.TemporalMemoExceptionType;
 import com.baro.memofolder.domain.MemoFolder;
 import com.baro.memofolder.domain.MemoFolderRepository;
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -81,7 +82,7 @@ public class TemporalMemoService {
     public List<FindTemporalMemoHistoriesResult> findTemporalMemos(FindTemporalMemoHistoriesQuery query) {
         validateQueryDateRange(query);
         List<TemporalMemo> temporalMemos = temporalMemoRepository.findAllByMemberIdAndCreatedAtBetween(query.memberId(),
-                query.startDate(), query.endDate());
+                query.startDate().atStartOfDay(), query.endDate().atTime(LocalTime.MAX));
         Map<LocalDate, List<TemporalMemo>> temporalMemosByDate = groupTemporalMemosByCreatedAt(temporalMemos);
 
         return temporalMemosByDate.keySet().stream()

--- a/src/main/java/com/baro/memo/application/dto/FindTemporalMemoHistoriesQuery.java
+++ b/src/main/java/com/baro/memo/application/dto/FindTemporalMemoHistoriesQuery.java
@@ -1,0 +1,10 @@
+package com.baro.memo.application.dto;
+
+import java.time.LocalDateTime;
+
+public record FindTemporalMemoHistoriesQuery(
+        Long memberId,
+        LocalDateTime startDate,
+        LocalDateTime endDate
+) {
+}

--- a/src/main/java/com/baro/memo/application/dto/FindTemporalMemoHistoriesQuery.java
+++ b/src/main/java/com/baro/memo/application/dto/FindTemporalMemoHistoriesQuery.java
@@ -1,10 +1,10 @@
 package com.baro.memo.application.dto;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 public record FindTemporalMemoHistoriesQuery(
         Long memberId,
-        LocalDateTime startDate,
-        LocalDateTime endDate
+        LocalDate startDate,
+        LocalDate endDate
 ) {
 }

--- a/src/main/java/com/baro/memo/application/dto/FindTemporalMemoHistoriesResult.java
+++ b/src/main/java/com/baro/memo/application/dto/FindTemporalMemoHistoriesResult.java
@@ -1,0 +1,10 @@
+package com.baro.memo.application.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record FindTemporalMemoHistoriesResult(
+        LocalDate createdAt,
+        List<FindTemporalMemoResult> temporalMemos
+) {
+}

--- a/src/main/java/com/baro/memo/application/dto/FindTemporalMemoResult.java
+++ b/src/main/java/com/baro/memo/application/dto/FindTemporalMemoResult.java
@@ -8,6 +8,7 @@ public record FindTemporalMemoResult(
         String content,
         String correctionContent,
         Boolean isCorrected,
+        Boolean isArchived,
         LocalDateTime createdAt
 ) {
 
@@ -17,6 +18,7 @@ public record FindTemporalMemoResult(
                 temporalMemo.getContent().value(),
                 temporalMemo.getCorrectionContent() == null ? null : temporalMemo.getCorrectionContent().value(),
                 temporalMemo.isCorrected(),
+                temporalMemo.isArchived(),
                 temporalMemo.getCreatedAt()
         );
     }

--- a/src/main/java/com/baro/memo/application/dto/FindTemporalMemoResult.java
+++ b/src/main/java/com/baro/memo/application/dto/FindTemporalMemoResult.java
@@ -1,0 +1,23 @@
+package com.baro.memo.application.dto;
+
+import com.baro.memo.domain.TemporalMemo;
+import java.time.LocalDateTime;
+
+public record FindTemporalMemoResult(
+        Long id,
+        String content,
+        String correctionContent,
+        Boolean isCorrected,
+        LocalDateTime createdAt
+) {
+
+    public static FindTemporalMemoResult from(TemporalMemo temporalMemo) {
+        return new FindTemporalMemoResult(
+                temporalMemo.getId(),
+                temporalMemo.getContent().value(),
+                temporalMemo.getCorrectionContent() == null ? null : temporalMemo.getCorrectionContent().value(),
+                temporalMemo.isCorrected(),
+                temporalMemo.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/baro/memo/domain/TemporalMemo.java
+++ b/src/main/java/com/baro/memo/domain/TemporalMemo.java
@@ -94,4 +94,8 @@ public class TemporalMemo extends BaseEntity {
         }
         this.correctionContent = correctionContent;
     }
+
+    public boolean isArchived() {
+        return Objects.nonNull(this.memo);
+    }
 }

--- a/src/main/java/com/baro/memo/domain/TemporalMemoRepository.java
+++ b/src/main/java/com/baro/memo/domain/TemporalMemoRepository.java
@@ -1,5 +1,6 @@
 package com.baro.memo.domain;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface TemporalMemoRepository {
@@ -11,4 +12,6 @@ public interface TemporalMemoRepository {
     TemporalMemo getById(Long id);
 
     void delete(TemporalMemo temporalMemo);
+
+    List<TemporalMemo> findAllByMemberIdAndCreatedAtBetween(Long memberId, LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/com/baro/memo/exception/TemporalMemoExceptionType.java
+++ b/src/main/java/com/baro/memo/exception/TemporalMemoExceptionType.java
@@ -10,6 +10,7 @@ public enum TemporalMemoExceptionType implements RequestExceptionType {
     NOT_EXIST_TEMPORAL_MEMO("TM02", "존재하지 않는 끄적이는 메모 입니다.", HttpStatus.NOT_FOUND),
     NOT_MATCH_OWNER("TM03", "끄적이는 메모에 대한 접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
     ALREADY_CORRECTED("TO04", "이미 맞춤법 검사가 완료된 끄적이는 메모 입니다.", HttpStatus.BAD_REQUEST),
+    NON_SEQUENTIAL_DATES_EXCEPTION("TM05", "조회 기간이 유효하지 않습니다.", HttpStatus.BAD_REQUEST),
     ;
 
     private final String errorCode;

--- a/src/main/java/com/baro/memo/infrastructure/TemporalMemoJpaRepository.java
+++ b/src/main/java/com/baro/memo/infrastructure/TemporalMemoJpaRepository.java
@@ -1,7 +1,11 @@
 package com.baro.memo.infrastructure;
 
 import com.baro.memo.domain.TemporalMemo;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TemporalMemoJpaRepository extends JpaRepository<TemporalMemo, Long> {
+
+    List<TemporalMemo> findAllByMemberIdAndCreatedAtBetween(Long memberId, LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/com/baro/memo/infrastructure/TemporalMemoRepositoryImpl.java
+++ b/src/main/java/com/baro/memo/infrastructure/TemporalMemoRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.baro.memo.domain.TemporalMemo;
 import com.baro.memo.domain.TemporalMemoRepository;
 import com.baro.memo.exception.TemporalMemoException;
 import com.baro.memo.exception.TemporalMemoExceptionType;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -33,5 +34,11 @@ public class TemporalMemoRepositoryImpl implements TemporalMemoRepository {
     @Override
     public void delete(TemporalMemo temporalMemo) {
         temporalMemoJpaRepository.delete(temporalMemo);
+    }
+
+    @Override
+    public List<TemporalMemo> findAllByMemberIdAndCreatedAtBetween(Long memberId, LocalDateTime start,
+                                                                   LocalDateTime end) {
+        return temporalMemoJpaRepository.findAllByMemberIdAndCreatedAtBetween(memberId, start, end);
     }
 }

--- a/src/main/java/com/baro/memo/presentation/TemporalMemoController.java
+++ b/src/main/java/com/baro/memo/presentation/TemporalMemoController.java
@@ -7,6 +7,8 @@ import com.baro.memo.application.dto.ApplyCorrectionCommand;
 import com.baro.memo.application.dto.ArchiveTemporalMemoCommand;
 import com.baro.memo.application.dto.ArchiveTemporalMemoResult;
 import com.baro.memo.application.dto.DeleteTemporalMemoCommand;
+import com.baro.memo.application.dto.FindTemporalMemoHistoriesQuery;
+import com.baro.memo.application.dto.FindTemporalMemoHistoriesResult;
 import com.baro.memo.application.dto.SaveTemporalMemoCommand;
 import com.baro.memo.application.dto.SaveTemporalMemoResult;
 import com.baro.memo.application.dto.UpdateTemporalMemoCommand;
@@ -15,14 +17,18 @@ import com.baro.memo.presentation.dto.ArchiveTemporalMemoRequest;
 import com.baro.memo.presentation.dto.SaveTemporalMemoRequest;
 import com.baro.memo.presentation.dto.UpdateTemporalMemoRequest;
 import java.net.URI;
+import java.time.LocalDate;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
@@ -94,5 +100,16 @@ public class TemporalMemoController {
                 request.content());
         temporalMemoService.applyCorrection(command);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping
+    public ResponseEntity<List<FindTemporalMemoHistoriesResult>> findTemporalMemos(
+            AuthMember authMember,
+            @RequestParam LocalDate startDate,
+            @RequestParam LocalDate endDate
+    ) {
+        FindTemporalMemoHistoriesQuery query = new FindTemporalMemoHistoriesQuery(authMember.id(), startDate, endDate);
+        List<FindTemporalMemoHistoriesResult> results = temporalMemoService.findTemporalMemos(query);
+        return ResponseEntity.ok(results);
     }
 }

--- a/src/test/java/com/baro/common/acceptance/memo/TemporalMemoAcceptanceSteps.java
+++ b/src/test/java/com/baro/common/acceptance/memo/TemporalMemoAcceptanceSteps.java
@@ -12,6 +12,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.requestF
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 
 import com.baro.auth.domain.Token;
 import com.baro.memo.presentation.dto.ApplyCorrectionRequest;
@@ -21,6 +22,7 @@ import com.baro.memo.presentation.dto.UpdateTemporalMemoRequest;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import java.time.LocalDate;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 
@@ -237,6 +239,55 @@ public class TemporalMemoAcceptanceSteps {
                 ).contentType(MediaType.APPLICATION_JSON_VALUE)
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + 토큰.accessToken()).body(바디)
                 .when().patch("/temporal-memos/{temporalMemoId}/correction", 끄적이는_메모_ID)
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 끄적이는_메모_조회_요청(Token 토큰, LocalDate 시작_날짜, LocalDate 끝_날짜) {
+        return RestAssured.given(requestSpec).log().all()
+                .filter(document(DEFAULT_REST_DOCS_PATH,
+                        queryParameters(
+                                parameterWithName("startDate").description("끄적이는 메모 조회 시작 날짜"),
+                                parameterWithName("endDate").description("끄적이는 메모 조회 끝 날짜")
+                        ),
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("인증 토큰")
+                        ),
+                        responseFields(
+                                fieldWithPath("[].createdAt").description("끄적이는 메모 생성 날짜"),
+                                fieldWithPath("[].temporalMemos").description("끄적이는 메모 목록"),
+                                fieldWithPath("[].temporalMemos[].id").description("끄적이는 메모 ID"),
+                                fieldWithPath("[].temporalMemos[].content").description("끄적이는 메모 내용"),
+                                fieldWithPath("[].temporalMemos[].correctionContent").description("끄적이는 메모 맞춤법 검사 결과"),
+                                fieldWithPath("[].temporalMemos[].isCorrected").description("끄적이는 메모 맞춤법 검사 결과 반영 여부"),
+                                fieldWithPath("[].temporalMemos[].isArchived").description("끄적이는 메모 아카이브 여부"),
+                                fieldWithPath("[].temporalMemos[].createdAt").description("끄적이는 메모 생성 시간")
+                        ))
+                ).contentType(MediaType.APPLICATION_JSON_VALUE)
+                .queryParam("startDate", 시작_날짜.toString())
+                .queryParam("endDate", 끝_날짜.toString())
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + 토큰.accessToken())
+                .when().get("/temporal-memos")
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 잘못된_끄적이는_메모_조회_요청(Token 토큰, LocalDate 시작_날짜, LocalDate 끝_날짜) {
+        return RestAssured.given(requestSpec).log().all()
+                .filter(document(DEFAULT_REST_DOCS_PATH,
+                        queryParameters(
+                                parameterWithName("startDate").description("끄적이는 메모 조회 시작 날짜"),
+                                parameterWithName("endDate").description("끄적이는 메모 조회 끝 날짜")
+                        ),
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("인증 토큰")
+                        ),
+                        responseFields(예외_응답()))
+                ).contentType(MediaType.APPLICATION_JSON_VALUE)
+                .queryParam("startDate", 시작_날짜.toString())
+                .queryParam("endDate", 끝_날짜.toString())
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + 토큰.accessToken())
+                .when().get("/temporal-memos")
                 .then().log().all()
                 .extract();
     }

--- a/src/test/java/com/baro/memo/application/TemporalMemoServiceTest.java
+++ b/src/test/java/com/baro/memo/application/TemporalMemoServiceTest.java
@@ -31,7 +31,7 @@ import com.baro.memofolder.domain.MemoFolderRepository;
 import com.baro.memofolder.exception.MemoFolderException;
 import com.baro.memofolder.exception.MemoFolderExceptionType;
 import com.baro.memofolder.fake.FakeMemoFolderRepository;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -340,14 +340,14 @@ class TemporalMemoServiceTest {
     @Test
     void 끄적이는_메모_조회시_최신_순으로_정렬() {
         // given
-        LocalDateTime standardDate = LocalDateTime.now();
+        LocalDate standardDate = LocalDate.now();
         Member member = memberRepository.save(MemberFixture.memberWithNickname("nickname1"));
         TemporalMemo temporalMemoA = TemporalMemo.of(member, "testContent1");
         TemporalMemo temporalMemoB = TemporalMemo.of(member, "testContent2");
         TemporalMemo temporalMemoC = TemporalMemo.of(member, "testContent3");
-        temporalMemoA.setCreatedAtForTest(standardDate.plusDays(3));
-        temporalMemoB.setCreatedAtForTest(standardDate.plusDays(3));
-        temporalMemoC.setCreatedAtForTest(standardDate.plusDays(1));
+        temporalMemoA.setCreatedAtForTest(standardDate.plusDays(3).atStartOfDay());
+        temporalMemoB.setCreatedAtForTest(standardDate.plusDays(3).atStartOfDay());
+        temporalMemoC.setCreatedAtForTest(standardDate.plusDays(1).atStartOfDay());
         temporalMemoRepository.save(temporalMemoA);
         temporalMemoRepository.save(temporalMemoB);
         temporalMemoRepository.save(temporalMemoC);
@@ -364,8 +364,8 @@ class TemporalMemoServiceTest {
                 () -> assertThat(temporalMemos).hasSize(2),
                 () -> assertThat(temporalMemos).isSortedAccordingTo(
                         Comparator.comparing(FindTemporalMemoHistoriesResult::createdAt).reversed()),
-                () -> assertThat(temporalMemos.get(0).createdAt()).isEqualTo(standardDate.plusDays(3).toLocalDate()),
-                () -> assertThat(temporalMemos.get(1).createdAt()).isEqualTo(standardDate.plusDays(1).toLocalDate()),
+                () -> assertThat(temporalMemos.get(0).createdAt()).isEqualTo(standardDate.plusDays(3)),
+                () -> assertThat(temporalMemos.get(1).createdAt()).isEqualTo(standardDate.plusDays(1)),
                 () -> assertThat(temporalMemos.get(0).temporalMemos()).hasSize(2),
                 () -> assertThat(temporalMemos.get(1).temporalMemos()).hasSize(1)
         );
@@ -374,14 +374,14 @@ class TemporalMemoServiceTest {
     @Test
     void 끄적이는_메모_조회시_조회_기간_내_끄적이는_메모만_조회_된다() {
         // given
-        LocalDateTime standardDate = LocalDateTime.now();
+        LocalDate standardDate = LocalDate.now();
         Member member = memberRepository.save(MemberFixture.memberWithNickname("nickname1"));
         TemporalMemo temporalMemoA = TemporalMemo.of(member, "testContent1");
         TemporalMemo temporalMemoB = TemporalMemo.of(member, "testContent2");
         TemporalMemo temporalMemoC = TemporalMemo.of(member, "testContent3");
-        temporalMemoA.setCreatedAtForTest(standardDate.plusDays(3));
-        temporalMemoB.setCreatedAtForTest(standardDate.plusDays(3));
-        temporalMemoC.setCreatedAtForTest(standardDate.plusDays(1));
+        temporalMemoA.setCreatedAtForTest(standardDate.plusDays(3).atStartOfDay());
+        temporalMemoB.setCreatedAtForTest(standardDate.plusDays(3).atStartOfDay());
+        temporalMemoC.setCreatedAtForTest(standardDate.plusDays(1).atStartOfDay());
         temporalMemoRepository.save(temporalMemoA);
         temporalMemoRepository.save(temporalMemoB);
         temporalMemoRepository.save(temporalMemoC);
@@ -400,7 +400,7 @@ class TemporalMemoServiceTest {
     @Test
     void 끄적이는_메모_조회시_조회_시작_기간이_끝_기간_보다_이후일_경우_예외_발생() {
         // given
-        LocalDateTime standardDate = LocalDateTime.now();
+        LocalDate standardDate = LocalDate.now();
         Member member = memberRepository.save(MemberFixture.memberWithNickname("nickname1"));
         TemporalMemo temporalMemoA = TemporalMemo.of(member, "testContent1");
         temporalMemoRepository.save(temporalMemoA);

--- a/src/test/java/com/baro/memo/fake/FakeTemporalMemoRepository.java
+++ b/src/test/java/com/baro/memo/fake/FakeTemporalMemoRepository.java
@@ -4,6 +4,7 @@ import com.baro.memo.domain.TemporalMemo;
 import com.baro.memo.domain.TemporalMemoRepository;
 import com.baro.memo.exception.TemporalMemoException;
 import com.baro.memo.exception.TemporalMemoExceptionType;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -18,15 +19,18 @@ public class FakeTemporalMemoRepository implements TemporalMemoRepository {
     @Override
     public TemporalMemo save(TemporalMemo temporalMemo) {
         if (Objects.isNull(temporalMemo.getId())) {
-            TemporalMemo newMemoFolder = new TemporalMemo(
+            TemporalMemo newTemporalMemo = new TemporalMemo(
                     id.getAndIncrement(),
                     temporalMemo.getMember(),
                     temporalMemo.getContent(),
                     temporalMemo.getCorrectionContent(),
                     temporalMemo.getMemo()
             );
-            temporalMemos.put(newMemoFolder.getId(), newMemoFolder);
-            return newMemoFolder;
+            if (Objects.nonNull(temporalMemo.getCreatedAt())) {
+                newTemporalMemo.setCreatedAtForTest(temporalMemo.getCreatedAt());
+            }
+            temporalMemos.put(newTemporalMemo.getId(), newTemporalMemo);
+            return newTemporalMemo;
         }
         temporalMemos.put(temporalMemo.getId(), temporalMemo);
         return temporalMemo;
@@ -49,5 +53,17 @@ public class FakeTemporalMemoRepository implements TemporalMemoRepository {
     public void delete(TemporalMemo temporalMemo) {
         this.getById(temporalMemo.getId());
         temporalMemos.remove(temporalMemo.getId());
+    }
+
+    @Override
+    public List<TemporalMemo> findAllByMemberIdAndCreatedAtBetween(Long memberId, LocalDateTime start,
+                                                                   LocalDateTime end) {
+        return temporalMemos.values().stream()
+                .filter(temporalMemo -> temporalMemo.getMember().getId().equals(memberId))
+                .filter(temporalMemo ->
+                        temporalMemo.getCreatedAt().isAfter(start) || temporalMemo.getCreatedAt().isEqual(start))
+                .filter(temporalMemo ->
+                        temporalMemo.getCreatedAt().isBefore(end) || temporalMemo.getCreatedAt().isEqual(end))
+                .toList();
     }
 }

--- a/src/test/java/com/baro/memo/presentation/TemproalMemoApiTest.java
+++ b/src/test/java/com/baro/memo/presentation/TemproalMemoApiTest.java
@@ -2,10 +2,12 @@ package com.baro.memo.presentation;
 
 import static com.baro.auth.fixture.OAuthMemberInfoFixture.아현;
 import static com.baro.auth.fixture.OAuthMemberInfoFixture.유빈;
+import static com.baro.auth.fixture.OAuthMemberInfoFixture.은지;
 import static com.baro.auth.fixture.OAuthMemberInfoFixture.준희;
 import static com.baro.auth.fixture.OAuthMemberInfoFixture.태연;
 import static com.baro.common.acceptance.AcceptanceSteps.권한_없음;
 import static com.baro.common.acceptance.AcceptanceSteps.생성됨;
+import static com.baro.common.acceptance.AcceptanceSteps.성공;
 import static com.baro.common.acceptance.AcceptanceSteps.응답값_없음;
 import static com.baro.common.acceptance.AcceptanceSteps.응답값을_검증한다;
 import static com.baro.common.acceptance.AcceptanceSteps.응답의_Location_헤더가_존재한다;
@@ -14,6 +16,7 @@ import static com.baro.common.acceptance.AcceptanceSteps.존재하지_않음;
 import static com.baro.common.acceptance.memo.TemporalMemoAcceptanceSteps.끄적이는_메모_맞춤법_검사_결과_반영_요청;
 import static com.baro.common.acceptance.memo.TemporalMemoAcceptanceSteps.끄적이는_메모_바디;
 import static com.baro.common.acceptance.memo.TemporalMemoAcceptanceSteps.끄적이는_메모_수정_바디;
+import static com.baro.common.acceptance.memo.TemporalMemoAcceptanceSteps.끄적이는_메모_조회_요청;
 import static com.baro.common.acceptance.memo.TemporalMemoAcceptanceSteps.끄적이는메모_삭제_요청;
 import static com.baro.common.acceptance.memo.TemporalMemoAcceptanceSteps.끄적이는메모_생성_요청;
 import static com.baro.common.acceptance.memo.TemporalMemoAcceptanceSteps.끄적이는메모_수정_요청;
@@ -23,6 +26,7 @@ import static com.baro.common.acceptance.memo.TemporalMemoAcceptanceSteps.맞춤
 import static com.baro.common.acceptance.memo.TemporalMemoAcceptanceSteps.메모_아카이브_요청_바디;
 import static com.baro.common.acceptance.memo.TemporalMemoAcceptanceSteps.잘못된_끄적이는_메모_맞춤법_검사_결과_반영_요청;
 import static com.baro.common.acceptance.memo.TemporalMemoAcceptanceSteps.잘못된_끄적이는_메모_생성_요청;
+import static com.baro.common.acceptance.memo.TemporalMemoAcceptanceSteps.잘못된_끄적이는_메모_조회_요청;
 import static com.baro.common.acceptance.memo.TemporalMemoAcceptanceSteps.잘못된_끄적이는메모_삭제_요청;
 import static com.baro.common.acceptance.memo.TemporalMemoAcceptanceSteps.잘못된_끄적이는메모_수정_요청;
 import static com.baro.common.acceptance.memo.TemporalMemoAcceptanceSteps.잘못된_끄적이는메모_아카이빙_요청;
@@ -33,6 +37,7 @@ import static com.baro.common.acceptance.memofolder.MemoFolderAcceptanceSteps.�
 import static com.baro.common.acceptance.memofolder.MemoFolderAcceptanceSteps.폴더_이름_바디;
 
 import com.baro.common.RestApiTest;
+import java.time.LocalDate;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
@@ -296,6 +301,42 @@ public class TemproalMemoApiTest extends RestApiTest {
 
         // when
         var 응답 = 잘못된_끄적이는_메모_맞춤법_검사_결과_반영_요청(준희, 준희의_끄적이는_메모_ID, 맞춤법_검사_결과_반영_바디);
+
+        // then
+        응답값을_검증한다(응답, 잘못된_요청);
+    }
+
+    @Test
+    void 끄적이는_메모를_조회한다() {
+        // given
+        var 은지 = 로그인(은지());
+        끄적이는메모를_생성하고_ID를_반환한다(은지, 끄적이는_메모_바디);
+        끄적이는메모를_생성하고_ID를_반환한다(은지, 끄적이는_메모_바디);
+        끄적이는메모를_생성하고_ID를_반환한다(은지, 끄적이는_메모_바디);
+
+        var 시작_날짜 = LocalDate.now();
+        var 끝_날짜 = LocalDate.now().plusDays(2);
+
+        // when
+        var 응답 = 끄적이는_메모_조회_요청(은지, 시작_날짜, 끝_날짜);
+
+        // then
+        응답값을_검증한다(응답, 성공);
+    }
+
+    @Test
+    void 끄적이는_메모를_조회할_때_시작_날짜가_끝_날짜보다_클_경우_예외를_반환한다() {
+        // given
+        var 은지 = 로그인(은지());
+        끄적이는메모를_생성하고_ID를_반환한다(은지, 끄적이는_메모_바디);
+        끄적이는메모를_생성하고_ID를_반환한다(은지, 끄적이는_메모_바디);
+        끄적이는메모를_생성하고_ID를_반환한다(은지, 끄적이는_메모_바디);
+
+        var 시작_날짜 = LocalDate.now().plusDays(2);
+        var 끝_날짜 = LocalDate.now();
+
+        // when
+        var 응답 = 잘못된_끄적이는_메모_조회_요청(은지, 시작_날짜, 끝_날짜);
 
         // then
         응답값을_검증한다(응답, 잘못된_요청);


### PR DESCRIPTION
## 관련된 이슈
Bar-191

## 작업 사항
- 끄적이는 메모 조회 쿼리 추가
   날짜를 parameter로 하여 조회하도록 하였습니다.
   응답은 날짜를 기준으로 그룹하였습니다.

- 테스트를 위해 createdAt을 설정하는 `setCreatedAtForTest()`이 추가되었습니다. 528dc7e7e2f098af5d576c26cc83582111cc9dc3
- 

## 기타
- on #41 

응답 포맷
```json
[
    {
        "createdAt": "2024-01-18",
        "temporalMemos": [
            {
                "id": 3,
                "content": "끄적이는 메모 컨텐츠",
                "correctionContent": null,
                "isCorrected": false,
                "isArchived": false,
                "createdAt": "2024-01-18T12:53:59.323598"
            },
            {
                "id": 4,
                "content": "끄적이는 메모 컨텐츠",
                "correctionContent": null,
                "isCorrected": false,
                "isArchived": false,
                "createdAt": "2024-01-18T12:53:59.34357"
            }
        ]
    },
    {
        "createdAt": "2024-01-15",
        "temporalMemos": [
            {
                "id": 1,
                "content": "끄적이는 메모 컨텐츠",
                "correctionContent": null,
                "isCorrected": false,
                "isArchived": false,
                "createdAt": "2024-01-18T12:53:59.323598"
            },
            {
                "id": 2,
                "content": "끄적이는 메모 컨텐츠",
                "correctionContent": null,
                "isCorrected": false,
                "isArchived": false,
                "createdAt": "2024-01-18T12:53:59.34357"
            }
        ]
    }
]
```
