### PR TITLE
feat: 만료된 끄적이는 메모 제거

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,6 @@ ARG JAR_FILE=build/libs/baro-0.0.1-SNAPSHOT.jar
 
 ADD ${JAR_FILE} baro.jar
 
+ENV TZ=Asia/Seoul
+
 ENTRYPOINT ["java", "-jar", "/baro.jar"]

--- a/src/main/java/com/baro/BaroApplication.java
+++ b/src/main/java/com/baro/BaroApplication.java
@@ -3,7 +3,9 @@ package com.baro;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.scheduling.annotation.EnableAsync;
 
+@EnableAsync
 @ConfigurationPropertiesScan
 @SpringBootApplication
 public class BaroApplication {

--- a/src/main/java/com/baro/common/config/SchedulingConfiguration.java
+++ b/src/main/java/com/baro/common/config/SchedulingConfiguration.java
@@ -1,0 +1,9 @@
+package com.baro.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulingConfiguration {
+}

--- a/src/main/java/com/baro/memo/batch/TemporalMemoScheduler.java
+++ b/src/main/java/com/baro/memo/batch/TemporalMemoScheduler.java
@@ -1,4 +1,28 @@
 package com.baro.memo.batch;
 
+import com.baro.memo.domain.TemporalMemoRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
 public class TemporalMemoScheduler {
+
+    private static final LocalDateTime A_WEEK_BEFORE = LocalDate.now().minusDays(7L).atStartOfDay();
+
+    private final TemporalMemoRepository temporalMemoRepository;
+
+    @Async
+    @Scheduled(cron = "0 0 0,12 * * ?", zone = "Asia/Seoul") // 매일 0시, 12시에 실행
+    public void deleteTemporalMemo() {
+        log.info("delete temporal memo job started");
+        temporalMemoRepository.deleteAllByCreatedAtLessThanEqual(A_WEEK_BEFORE);
+        log.info("delete temporal memo job finished");
+    }
 }

--- a/src/main/java/com/baro/memo/batch/TemporalMemoScheduler.java
+++ b/src/main/java/com/baro/memo/batch/TemporalMemoScheduler.java
@@ -1,0 +1,4 @@
+package com.baro.memo.batch;
+
+public class TemporalMemoScheduler {
+}

--- a/src/main/java/com/baro/memo/domain/TemporalMemoRepository.java
+++ b/src/main/java/com/baro/memo/domain/TemporalMemoRepository.java
@@ -15,5 +15,5 @@ public interface TemporalMemoRepository {
 
     List<TemporalMemo> findAllByMemberIdAndCreatedAtBetween(Long memberId, LocalDateTime start, LocalDateTime end);
 
-    void deleteAllByCreatedAtLessThanEqual(LocalDateTime localDateTime);
+    void deleteAllByCreatedAtLessThanEqual(LocalDateTime weekBefore);
 }

--- a/src/main/java/com/baro/memo/domain/TemporalMemoRepository.java
+++ b/src/main/java/com/baro/memo/domain/TemporalMemoRepository.java
@@ -14,4 +14,6 @@ public interface TemporalMemoRepository {
     void delete(TemporalMemo temporalMemo);
 
     List<TemporalMemo> findAllByMemberIdAndCreatedAtBetween(Long memberId, LocalDateTime start, LocalDateTime end);
+
+    void deleteAllByCreatedAtLessThanEqual(LocalDateTime localDateTime);
 }

--- a/src/main/java/com/baro/memo/infrastructure/TemporalMemoJpaRepository.java
+++ b/src/main/java/com/baro/memo/infrastructure/TemporalMemoJpaRepository.java
@@ -8,4 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface TemporalMemoJpaRepository extends JpaRepository<TemporalMemo, Long> {
 
     List<TemporalMemo> findAllByMemberIdAndCreatedAtBetween(Long memberId, LocalDateTime start, LocalDateTime end);
+
+    void deleteAllByCreatedAtLessThanEqual(LocalDateTime localDateTime);
 }

--- a/src/main/java/com/baro/memo/infrastructure/TemporalMemoRepositoryImpl.java
+++ b/src/main/java/com/baro/memo/infrastructure/TemporalMemoRepositoryImpl.java
@@ -43,7 +43,7 @@ public class TemporalMemoRepositoryImpl implements TemporalMemoRepository {
     }
 
     @Override
-    public void deleteAllByCreatedAtLessThanEqual(final LocalDateTime localDateTime) {
-        temporalMemoJpaRepository.deleteAllByCreatedAtLessThanEqual(localDateTime);
+    public void deleteAllByCreatedAtLessThanEqual(LocalDateTime weekBefore) {
+        temporalMemoJpaRepository.deleteAllByCreatedAtLessThanEqual(weekBefore);
     }
 }

--- a/src/main/java/com/baro/memo/infrastructure/TemporalMemoRepositoryImpl.java
+++ b/src/main/java/com/baro/memo/infrastructure/TemporalMemoRepositoryImpl.java
@@ -41,4 +41,9 @@ public class TemporalMemoRepositoryImpl implements TemporalMemoRepository {
                                                                    LocalDateTime end) {
         return temporalMemoJpaRepository.findAllByMemberIdAndCreatedAtBetween(memberId, start, end);
     }
+
+    @Override
+    public void deleteAllByCreatedAtLessThanEqual(final LocalDateTime localDateTime) {
+        temporalMemoJpaRepository.deleteAllByCreatedAtLessThanEqual(localDateTime);
+    }
 }

--- a/src/test/java/com/baro/memo/batch/TemporalMemoSchedulerTest.java
+++ b/src/test/java/com/baro/memo/batch/TemporalMemoSchedulerTest.java
@@ -1,0 +1,52 @@
+package com.baro.memo.batch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.baro.member.domain.Member;
+import com.baro.member.fixture.MemberFixture;
+import com.baro.memo.domain.TemporalMemo;
+import com.baro.memo.domain.TemporalMemoRepository;
+import com.baro.memo.fake.FakeTemporalMemoRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class TemporalMemoSchedulerTest {
+
+    private static final LocalDateTime _7DAYS_BEFORE = LocalDate.now().minusDays(7L).atStartOfDay();
+    private static final LocalDateTime _3DAYS_BEFORE = LocalDate.now().minusDays(3L).atStartOfDay();
+
+    private TemporalMemoScheduler temporalMemoScheduler;
+    private TemporalMemoRepository temporalMemoRepository;
+
+    @BeforeEach
+    void setUp() {
+        temporalMemoRepository = new FakeTemporalMemoRepository();
+        temporalMemoScheduler = new TemporalMemoScheduler(temporalMemoRepository);
+    }
+
+    @Test
+    void 일주일이_지난_끄적이는_메모를_삭제한다() {
+        // given
+        Member member = MemberFixture.memberWithNickname("baro");
+        TemporalMemo temporalMemoA = temporalMemoRepository.save(TemporalMemo.of(member, "끄적이는 메모A"));
+        TemporalMemo temporalMemoB = temporalMemoRepository.save(TemporalMemo.of(member, "끄적이는 메모B"));
+        TemporalMemo temporalMemoC = temporalMemoRepository.save(TemporalMemo.of(member, "끄적이는 메모C"));
+        temporalMemoA.setCreatedAtForTest(_7DAYS_BEFORE);
+        temporalMemoB.setCreatedAtForTest(_7DAYS_BEFORE);
+        temporalMemoC.setCreatedAtForTest(_3DAYS_BEFORE);
+
+        // when
+        temporalMemoScheduler.deleteTemporalMemo();
+
+        // then
+        List<TemporalMemo> all = temporalMemoRepository.findAll();
+        assertThat(all).containsExactly(temporalMemoC);
+    }
+}

--- a/src/test/java/com/baro/memo/fake/FakeTemporalMemoRepository.java
+++ b/src/test/java/com/baro/memo/fake/FakeTemporalMemoRepository.java
@@ -66,4 +66,13 @@ public class FakeTemporalMemoRepository implements TemporalMemoRepository {
                         temporalMemo.getCreatedAt().isBefore(end) || temporalMemo.getCreatedAt().isEqual(end))
                 .toList();
     }
+
+    @Override
+    public void deleteAllByCreatedAtLessThanEqual(LocalDateTime weekBefore) {
+        temporalMemos.values().stream()
+                .filter(temporalMemo -> temporalMemo.getCreatedAt().isBefore(weekBefore) || temporalMemo.getCreatedAt()
+                        .isEqual(weekBefore))
+                .map(TemporalMemo::getId)
+                .forEach(temporalMemos::remove);
+    }
 }


### PR DESCRIPTION
## 관련된 이슈
Bar-218

## 작업 사항
- 만료된(7일 이전) 끄적이는 메모를 삭제하는 크론잡을 추가하였습니다.
- 서비스에서 사용될 batch성 작업이 적어 제일 간단하게 `@Schedule` 을 사용하였습니다. (매일 0, 12시에 실행됩니다) 0ab946e2e7bc1c806c3439e01d6b4035e26a3a71
- 도커 타임존을 설정하였습니다. 807428a9d462f4459c72574e4021689610b58532
