### PR TITLE
 refactor: 소셜로그인 redirect uri 경로 수정

### DIFF
--- a/src/main/java/com/baro/auth/application/oauth/OAuthClient.java
+++ b/src/main/java/com/baro/auth/application/oauth/OAuthClient.java
@@ -6,7 +6,7 @@ import com.baro.auth.domain.oauth.OAuthServiceType;
 
 public interface OAuthClient {
 
-    String getSignInUrl();
+    String getSignInUrl(String host);
 
     OAuthServiceType getOAuthService();
 

--- a/src/main/java/com/baro/auth/application/oauth/OAuthInfoProvider.java
+++ b/src/main/java/com/baro/auth/application/oauth/OAuthInfoProvider.java
@@ -6,7 +6,6 @@ import static java.util.stream.Collectors.toMap;
 import com.baro.auth.application.oauth.dto.OAuthMemberInfo;
 import com.baro.auth.application.oauth.dto.OAuthTokenInfo;
 import com.baro.auth.domain.oauth.OAuthServiceType;
-
 import java.util.Map;
 import java.util.Set;
 import org.springframework.stereotype.Component;
@@ -23,9 +22,9 @@ public class OAuthInfoProvider {
                 .collect(toMap(OAuthClient::getOAuthService, identity()));
     }
 
-    public String getSignInUrl(String oAuthService) {
+    public String getSignInUrl(String oAuthService, String host) {
         OAuthClient client = getClient(oAuthService);
-        return client.getSignInUrl();
+        return client.getSignInUrl(host);
     }
 
     public OAuthMemberInfo getMemberInfo(String oAuthService, String code) {

--- a/src/main/java/com/baro/auth/infra/oauth/google/GoogleOAuthClient.java
+++ b/src/main/java/com/baro/auth/infra/oauth/google/GoogleOAuthClient.java
@@ -1,18 +1,17 @@
 package com.baro.auth.infra.oauth.google;
 
+import com.baro.auth.application.oauth.OAuthClient;
 import com.baro.auth.application.oauth.dto.OAuthMemberInfo;
 import com.baro.auth.application.oauth.dto.OAuthTokenInfo;
 import com.baro.auth.domain.oauth.OAuthServiceType;
 import com.baro.auth.infra.oauth.google.config.GoogleOAuthProperty;
 import com.baro.auth.infra.oauth.google.dto.GoogleMemberResponse;
 import com.baro.auth.infra.oauth.google.dto.GoogleTokenResponse;
-import com.baro.auth.application.oauth.OAuthClient;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponentsBuilder;
-
-import java.util.LinkedHashMap;
-import java.util.Map;
 
 @RequiredArgsConstructor
 @Component
@@ -22,12 +21,12 @@ public class GoogleOAuthClient implements OAuthClient {
     private final GoogleRequestApi googleRequestApi;
 
     @Override
-    public String getSignInUrl() {
+    public String getSignInUrl(String host) {
         return UriComponentsBuilder
                 .fromUriString(googleOAuthProperty.signInAuthorizeUrl())
                 .queryParam("client_id", googleOAuthProperty.clientId())
-                .queryParam("redirect_uri", googleOAuthProperty.redirectUri())
                 .queryParam("response_type", googleOAuthProperty.responseType())
+                .queryParam("redirect_uri", host + googleOAuthProperty.redirectUri())
                 .queryParam("scope", String.join(",", googleOAuthProperty.scope()))
                 .toUriString();
     }

--- a/src/main/java/com/baro/auth/infra/oauth/kakao/KakaoOAuthClient.java
+++ b/src/main/java/com/baro/auth/infra/oauth/kakao/KakaoOAuthClient.java
@@ -1,16 +1,14 @@
 package com.baro.auth.infra.oauth.kakao;
 
+import com.baro.auth.application.oauth.OAuthClient;
 import com.baro.auth.application.oauth.dto.OAuthMemberInfo;
 import com.baro.auth.application.oauth.dto.OAuthTokenInfo;
 import com.baro.auth.domain.oauth.OAuthServiceType;
 import com.baro.auth.infra.oauth.kakao.config.KakaoOAuthProperty;
 import com.baro.auth.infra.oauth.kakao.dto.KakaoMemberResponse;
 import com.baro.auth.infra.oauth.kakao.dto.KakaoTokenResponse;
-import com.baro.auth.application.oauth.OAuthClient;
-
 import java.util.LinkedHashMap;
 import java.util.Map;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -23,12 +21,12 @@ public class KakaoOAuthClient implements OAuthClient {
     private final KakaoRequestApi kakaoRequestApi;
 
     @Override
-    public String getSignInUrl() {
+    public String getSignInUrl(String host) {
         return UriComponentsBuilder
                 .fromUriString(kakaoOAuthProperty.signInAuthorizeUrl())
                 .queryParam("response_type", kakaoOAuthProperty.responseType())
                 .queryParam("client_id", kakaoOAuthProperty.clientId())
-                .queryParam("redirect_uri", kakaoOAuthProperty.redirectUrl())
+                .queryParam("redirect_uri", host + kakaoOAuthProperty.redirectUri())
                 .queryParam("scope", String.join(",", kakaoOAuthProperty.scope()))
                 .toUriString();
     }
@@ -38,7 +36,7 @@ public class KakaoOAuthClient implements OAuthClient {
         Map<String, String> params = new LinkedHashMap<>();
         params.put("grant_type", "authorization_code");
         params.put("client_id", kakaoOAuthProperty.clientId());
-        params.put("redirect_uri", kakaoOAuthProperty.redirectUrl());
+        params.put("redirect_uri", kakaoOAuthProperty.redirectUri());
         params.put("code", authCode);
         params.put("client_secret", kakaoOAuthProperty.clientSecret());
         KakaoTokenResponse kakaoTokenResponse = kakaoRequestApi.requestToken(params);

--- a/src/main/java/com/baro/auth/infra/oauth/kakao/config/KakaoOAuthProperty.java
+++ b/src/main/java/com/baro/auth/infra/oauth/kakao/config/KakaoOAuthProperty.java
@@ -5,7 +5,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "oauth.kakao")
 public record KakaoOAuthProperty(
         String clientId,
-        String redirectUrl,
+        String redirectUri,
         String responseType,
         String signInAuthorizeUrl,
         String[] scope,

--- a/src/main/java/com/baro/auth/infra/oauth/naver/NaverOAuthClient.java
+++ b/src/main/java/com/baro/auth/infra/oauth/naver/NaverOAuthClient.java
@@ -21,12 +21,12 @@ public class NaverOAuthClient implements OAuthClient {
     private final NaverRequestApi naverRequestApi;
 
     @Override
-    public String getSignInUrl() {
+    public String getSignInUrl(String host) {
         return UriComponentsBuilder
                 .fromUriString(naverOAuthProperty.signInAuthorizeUrl())
                 .queryParam("response_type", naverOAuthProperty.responseType())
                 .queryParam("client_id", naverOAuthProperty.clientId())
-                .queryParam("redirect_uri", naverOAuthProperty.redirectUri())
+                .queryParam("redirect_uri", host + naverOAuthProperty.redirectUri())
                 .queryParam("state", naverOAuthProperty.state())
                 .toUriString();
     }

--- a/src/main/java/com/baro/auth/presentation/AuthController.java
+++ b/src/main/java/com/baro/auth/presentation/AuthController.java
@@ -7,6 +7,7 @@ import com.baro.auth.application.oauth.dto.OAuthMemberInfo;
 import com.baro.auth.domain.AuthMember;
 import com.baro.auth.domain.Token;
 import com.baro.auth.presentation.dto.OAuthServiceUrlResponse;
+import com.baro.common.presentation.RequestHost;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -24,8 +25,8 @@ public class AuthController {
     private final OAuthInfoProvider oAuthInfoProvider;
 
     @GetMapping("/oauth/{oauthType}")
-    ResponseEntity<OAuthServiceUrlResponse> signInRequestUrl(@PathVariable String oauthType) {
-        String signInUrl = oAuthInfoProvider.getSignInUrl(oauthType);
+    ResponseEntity<OAuthServiceUrlResponse> signInRequestUrl(@PathVariable String oauthType, @RequestHost String host) {
+        String signInUrl = oAuthInfoProvider.getSignInUrl(oauthType, host);
         return ResponseEntity.ok(new OAuthServiceUrlResponse(signInUrl));
     }
 

--- a/src/main/java/com/baro/common/config/WebConfig.java
+++ b/src/main/java/com/baro/common/config/WebConfig.java
@@ -2,6 +2,7 @@ package com.baro.common.config;
 
 import com.baro.auth.presentation.AuthInterceptor;
 import com.baro.auth.presentation.AuthenticationArgumentResolver;
+import com.baro.common.presentation.RequestHostArgumentResolver;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
@@ -15,10 +16,12 @@ public class WebConfig implements WebMvcConfigurer {
 
     private final AuthenticationArgumentResolver authenticationArgumentResolver;
     private final AuthInterceptor authInterceptor;
+    private final RequestHostArgumentResolver requestHostArgumentResolver;
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(authenticationArgumentResolver);
+        resolvers.add(requestHostArgumentResolver);
     }
 
     @Override
@@ -27,6 +30,7 @@ public class WebConfig implements WebMvcConfigurer {
                 .addPathPatterns("/**")
                 .excludePathPatterns("/docs/**")
                 .excludePathPatterns("/auth/**")
-                .excludePathPatterns("/favicon.ico");
+                .excludePathPatterns("/favicon.ico")
+                .excludePathPatterns("/test/**");
     }
 }

--- a/src/main/java/com/baro/common/exception/CommonRequestExceptionType.java
+++ b/src/main/java/com/baro/common/exception/CommonRequestExceptionType.java
@@ -8,6 +8,7 @@ public enum CommonRequestExceptionType implements RequestExceptionType {
 
     MISSING_PARAMETER_EXCEPTION("CM01", "Request parameter is empty", HttpStatus.BAD_REQUEST),
     INVALID_TYPE_REQUEST_EXCEPTION("CM02", "Request type is invalid", HttpStatus.BAD_REQUEST),
+    REQUIRED_HEADER_EXCEPTION("CM03", "Request header is empty", HttpStatus.BAD_REQUEST),
     ;
 
     private final String errorCode;

--- a/src/main/java/com/baro/common/presentation/RequestHost.java
+++ b/src/main/java/com/baro/common/presentation/RequestHost.java
@@ -1,0 +1,11 @@
+package com.baro.common.presentation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(value = RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface RequestHost {
+}

--- a/src/main/java/com/baro/common/presentation/RequestHostArgumentResolver.java
+++ b/src/main/java/com/baro/common/presentation/RequestHostArgumentResolver.java
@@ -1,0 +1,45 @@
+package com.baro.common.presentation;
+
+import static com.baro.common.exception.CommonRequestExceptionType.REQUIRED_HEADER_EXCEPTION;
+
+import com.baro.common.exception.RequestException;
+import com.baro.common.exception.RequestExceptionType;
+import java.util.Objects;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class RequestHostArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private static final String HOST_HEADER_KEY = "Origin";
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(RequestHost.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        String host = webRequest.getHeader(HOST_HEADER_KEY);
+        validateHeaderIsNonNull(host);
+        return host;
+    }
+
+    private void validateHeaderIsNonNull(String host) {
+        if (Objects.nonNull(host)) {
+            return;
+        }
+
+        throw new RequestException() {
+            @Override
+            public RequestExceptionType exceptionType() {
+                return REQUIRED_HEADER_EXCEPTION;
+            }
+        };
+    }
+}

--- a/src/test/java/com/baro/auth/application/oauth/OAuthInfoProviderTest.java
+++ b/src/test/java/com/baro/auth/application/oauth/OAuthInfoProviderTest.java
@@ -33,36 +33,39 @@ class OAuthInfoProviderTest {
     void 카카오의_SignInUrl을_가져온다() {
         // given
         String oAuthService = OAuthServiceType.KAKAO.name();
+        String host = "http://localhost:3000";
 
         // when
-        String signInUrl = oAuthInfoProvider.getSignInUrl(oAuthService);
+        String signInUrl = oAuthInfoProvider.getSignInUrl(oAuthService, host);
 
         // then
-        assertThat(signInUrl).isEqualTo(fakeKakaoOAuthClient.getSignInUrl());
+        assertThat(signInUrl).isEqualTo(fakeKakaoOAuthClient.getSignInUrl(host));
     }
 
     @Test
     void 네이버의_SignInUrl을_가져온다() {
         // given
         String oAuthService = OAuthServiceType.NAVER.name();
+        String host = "http://localhost:3000";
 
         // when
-        String signInUrl = oAuthInfoProvider.getSignInUrl(oAuthService);
+        String signInUrl = oAuthInfoProvider.getSignInUrl(oAuthService, host);
 
         // then
-        assertThat(signInUrl).isEqualTo(fakeNaverOAuthClient.getSignInUrl());
+        assertThat(signInUrl).isEqualTo(fakeNaverOAuthClient.getSignInUrl(host));
     }
 
     @Test
     void 구글의_SignInUrl을_가져온다() {
         // given
         String oAuthService = OAuthServiceType.GOOGLE.name();
+        String host = "http://localhost:3000";
 
         // when
-        String signInUrl = oAuthInfoProvider.getSignInUrl(oAuthService);
+        String signInUrl = oAuthInfoProvider.getSignInUrl(oAuthService, host);
 
         // then
-        assertThat(signInUrl).isEqualTo(fakeGoogleOAuthClient.getSignInUrl());
+        assertThat(signInUrl).isEqualTo(fakeGoogleOAuthClient.getSignInUrl(host));
     }
 
     @Test

--- a/src/test/java/com/baro/auth/fake/oauth/FakeGoogleOAuthClient.java
+++ b/src/test/java/com/baro/auth/fake/oauth/FakeGoogleOAuthClient.java
@@ -8,7 +8,7 @@ import com.baro.auth.domain.oauth.OAuthServiceType;
 public class FakeGoogleOAuthClient implements OAuthClient {
 
     @Override
-    public String getSignInUrl() {
+    public String getSignInUrl(String host) {
         return null;
     }
 

--- a/src/test/java/com/baro/auth/fake/oauth/FakeKakaoOAuthClient.java
+++ b/src/test/java/com/baro/auth/fake/oauth/FakeKakaoOAuthClient.java
@@ -8,7 +8,7 @@ import com.baro.auth.domain.oauth.OAuthServiceType;
 public class FakeKakaoOAuthClient implements OAuthClient {
 
     @Override
-    public String getSignInUrl() {
+    public String getSignInUrl(String host) {
         return null;
     }
 

--- a/src/test/java/com/baro/auth/fake/oauth/FakeNaverOAuthClient.java
+++ b/src/test/java/com/baro/auth/fake/oauth/FakeNaverOAuthClient.java
@@ -7,7 +7,7 @@ import com.baro.auth.domain.oauth.OAuthServiceType;
 
 public class FakeNaverOAuthClient implements OAuthClient {
     @Override
-    public String getSignInUrl() {
+    public String getSignInUrl(String host) {
         return null;
     }
 

--- a/src/test/java/com/baro/auth/presentation/oauth/OAuthApiTest.java
+++ b/src/test/java/com/baro/auth/presentation/oauth/OAuthApiTest.java
@@ -17,8 +17,11 @@ class OAuthApiTest extends RestApiTest {
 
     @Test
     void OAuth_로그인시_필요한_url을_반환한다() {
+        // givne
+        var 요청_호스트 = "http://localhost:3000";
+
         // when
-        var 응답 = 리다이렉트_URI_요청("kakao");
+        var 응답 = 리다이렉트_URI_요청("kakao", 요청_호스트);
 
         // then
         응답값을_검증한다(응답, 성공);

--- a/src/test/java/com/baro/common/acceptance/auth/OAuthAcceptanceSteps.java
+++ b/src/test/java/com/baro/common/acceptance/auth/OAuthAcceptanceSteps.java
@@ -16,7 +16,7 @@ import org.springframework.http.MediaType;
 
 public class OAuthAcceptanceSteps {
 
-    public static ExtractableResponse<Response> 리다이렉트_URI_요청(String oauthServiceType) {
+    public static ExtractableResponse<Response> 리다이렉트_URI_요청(String oauthServiceType, String 요청_호스트) {
         var url = "/auth/oauth/{oauthType}";
 
         return given(requestSpec).log().all()
@@ -29,6 +29,7 @@ public class OAuthAcceptanceSteps {
                         )
                 ))
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Origin", 요청_호스트)
                 .when().get(url, oauthServiceType)
                 .then().log().all()
                 .extract();

--- a/src/test/java/com/baro/common/presentation/RequestHostArgumentResolverTest.java
+++ b/src/test/java/com/baro/common/presentation/RequestHostArgumentResolverTest.java
@@ -1,0 +1,93 @@
+package com.baro.common.presentation;
+
+import static com.baro.common.acceptance.AcceptanceSteps.성공;
+import static com.baro.common.acceptance.AcceptanceSteps.응답값을_검증한다;
+import static com.baro.common.acceptance.AcceptanceSteps.응답의_특정_필드값을_검증한다;
+import static com.baro.common.acceptance.AcceptanceSteps.잘못된_요청;
+import static com.baro.common.presentation.RequestHostArgumentResolverAcceptanceSteps.Origin_헤더가_없는_요청;
+import static com.baro.common.presentation.RequestHostArgumentResolverAcceptanceSteps.Origin_헤더를_포함한_요청;
+import static io.restassured.RestAssured.given;
+
+import com.baro.common.RestApiTest;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class RequestHostArgumentResolverTest extends RestApiTest {
+
+    @Autowired
+    RequestHostArgumentResolver requestHostArgumentResolver;
+
+    @Test
+    void 매개변수에_RequestHost가_존재하는경우_Argument_resolver를_거친다() {
+        // given
+        var 요청_도메인 = "http://localhost:3000";
+
+        // when
+        var 응답 = Origin_헤더를_포함한_요청(요청_도메인);
+
+        // then
+        응답값을_검증한다(응답, 성공);
+        응답의_특정_필드값을_검증한다(응답, "host", 요청_도메인);
+    }
+
+    @Test
+    void RequestHost가_존재하지_않으면_예외_발생() {
+        // given
+        var 요청_도메인 = "http://localhost:3000";
+
+        // when
+        var 응답 = Origin_헤더가_없는_요청(요청_도메인);
+
+        // then
+        응답값을_검증한다(응답, 잘못된_요청);
+    }
+}
+
+@RestController
+@RequestMapping("/test")
+class RequestHostTestController {
+
+    @GetMapping("/host")
+    private ResponseEntity<TestResponse> authUserMethod(@RequestHost String host) {
+        return ResponseEntity.ok().body(new TestResponse(host));
+    }
+
+    record TestResponse(String host) {
+    }
+}
+
+class RequestHostArgumentResolverAcceptanceSteps {
+
+    public static ExtractableResponse<Response> Origin_헤더를_포함한_요청(String 요청_도메인) {
+        var url = "/test/host";
+
+        return given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header(HttpHeaders.ORIGIN, 요청_도메인)
+                .when().get(url)
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> Origin_헤더가_없는_요청(String 요청_도메인) {
+        var url = "/test/host";
+
+        return given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().get(url)
+                .then().log().all()
+                .extract();
+    }
+}


### PR DESCRIPTION
## 관련된 이슈
Bar-224

## 작업 사항
- 로그인 url 생성 시, 요청 도메인에 따라 동적으로 redirect_uri가 생성됩니다.
- 요청 Header에 "Origin"이 요구 됩니다.
- 요청 서비스에 따라 `${도메인}/redirect/{service}`로 지정됩니다.
