### PR TITLE
feat: 프로필 이미지 제거 api

### DIFF
--- a/src/main/java/com/baro/common/image/ImageStorageClient.java
+++ b/src/main/java/com/baro/common/image/ImageStorageClient.java
@@ -3,7 +3,9 @@ package com.baro.common.image;
 import com.baro.common.image.dto.ImageUploadResult;
 import org.springframework.web.multipart.MultipartFile;
 
-public interface ImageUploader {
+public interface ImageStorageClient {
 
     ImageUploadResult upload(MultipartFile file);
+
+    void delete(String key);
 }

--- a/src/main/java/com/baro/common/infra/aws/s3/AwsImageStorageClient.java
+++ b/src/main/java/com/baro/common/infra/aws/s3/AwsImageStorageClient.java
@@ -1,7 +1,7 @@
 package com.baro.common.infra.aws.s3;
 
+import com.baro.common.image.ImageStorageClient;
 import com.baro.common.image.ImageUploadException;
-import com.baro.common.image.ImageUploader;
 import com.baro.common.image.dto.ImageUploadResult;
 import com.baro.common.utils.ImageExtensionConverter;
 import java.io.ByteArrayInputStream;
@@ -13,11 +13,12 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 @RequiredArgsConstructor
 @Component
-public class AwsImageUploader implements ImageUploader {
+public class AwsImageStorageClient implements ImageStorageClient {
 
     private final S3Client s3Client;
     private final AwsS3Property awsS3Property;
@@ -42,6 +43,15 @@ public class AwsImageUploader implements ImageUploader {
         } catch (IOException ioException) {
             throw new ImageUploadException("Error on converting or uploading image", ioException);
         }
+    }
+
+    @Override
+    public void delete(String key) {
+        DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
+                .bucket(awsS3Property.bucket())
+                .key(awsS3Property.key() + key)
+                .build();
+        s3Client.deleteObject(deleteObjectRequest);
     }
 
     private String changeToUrlSafetyKey(MultipartFile file) {

--- a/src/main/java/com/baro/member/application/MemberService.java
+++ b/src/main/java/com/baro/member/application/MemberService.java
@@ -1,5 +1,6 @@
 package com.baro.member.application;
 
+import com.baro.common.image.ImageStorageClient;
 import com.baro.member.application.dto.GetMemberProfileResult;
 import com.baro.member.application.dto.UpdateMemberProfileCommand;
 import com.baro.member.domain.Member;
@@ -16,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberService {
 
     private final MemberRepository memberRepository;
+    private final ImageStorageClient imageStorageClient;
 
     @Transactional(readOnly = true)
     public GetMemberProfileResult getMyProfile(Long id) {
@@ -33,5 +35,12 @@ public class MemberService {
         if (memberRepository.existByNickname(nickName)) {
             throw new MemberException(MemberExceptionType.NICKNAME_DUPLICATION);
         }
+    }
+
+    public void deleteProfileImage(Long id) {
+        Member member = memberRepository.getById(id);
+        String profileImageKey = member.getProfileImageUrl();
+        member.deleteProfileImage();
+        imageStorageClient.delete(profileImageKey);
     }
 }

--- a/src/main/java/com/baro/member/domain/Member.java
+++ b/src/main/java/com/baro/member/domain/Member.java
@@ -1,6 +1,8 @@
 package com.baro.member.domain;
 
 import com.baro.common.entity.BaseEntity;
+import com.baro.member.exception.MemberException;
+import com.baro.member.exception.MemberExceptionType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -9,6 +11,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -46,12 +49,14 @@ public class Member extends BaseEntity {
     private String oAuthServiceType;
 
     @Builder
-    public Member(String name, String email, String nickname, String oAuthId, String oAuthServiceType) {
+    public Member(String name, String email, String nickname, String oAuthId, String oAuthServiceType,
+                  String profileImageUrl) {
         this.name = name;
         this.email = email;
         this.nickname = MemberNickname.from(nickname);
         this.oAuthId = oAuthId;
         this.oAuthServiceType = oAuthServiceType;
+        this.profileImageUrl = profileImageUrl;
     }
 
     public Member(Long id, String name, String email, String nickname, String oAuthId, String oAuthServiceType) {
@@ -63,8 +68,26 @@ public class Member extends BaseEntity {
         this.oAuthServiceType = oAuthServiceType;
     }
 
+    public Member(Long id, String name, String email, String nickname, String profileImageUrl, String oAuthId,
+                  String oAuthServiceType) {
+        this.id = id;
+        this.name = name;
+        this.email = email;
+        this.nickname = MemberNickname.from(nickname);
+        this.profileImageUrl = profileImageUrl;
+        this.oAuthId = oAuthId;
+        this.oAuthServiceType = oAuthServiceType;
+    }
+
     public void updateProfile(String name, String nickname) {
         this.name = name;
         this.nickname = MemberNickname.from(nickname);
+    }
+
+    public void deleteProfileImage() {
+        if (Objects.isNull(this.profileImageUrl)) {
+            throw new MemberException(MemberExceptionType.NOT_EXIST_PROFILE_IMAGE);
+        }
+        this.profileImageUrl = null;
     }
 }

--- a/src/main/java/com/baro/member/exception/MemberExceptionType.java
+++ b/src/main/java/com/baro/member/exception/MemberExceptionType.java
@@ -12,6 +12,7 @@ public enum MemberExceptionType implements RequestExceptionType {
     NICKNAME_DUPLICATION("ME03", "이미 존재하는 닉네임 입니다.", HttpStatus.BAD_REQUEST),
     OVER_MAX_SIZE_NICKNAME("ME04", "닉네임은 최대 30자까지 입력 가능합니다.", HttpStatus.BAD_REQUEST),
     EMPTY_NICKNAME("ME05", "빈 닉네임은 입력할 수 없습니다.", HttpStatus.BAD_REQUEST),
+    NOT_EXIST_PROFILE_IMAGE("ME06", "프로필 이미지가 존재 하지 않습니다.", HttpStatus.BAD_REQUEST),
     ;
 
     private final String errorCode;

--- a/src/main/java/com/baro/member/presentation/MemberController.java
+++ b/src/main/java/com/baro/member/presentation/MemberController.java
@@ -7,6 +7,7 @@ import com.baro.member.application.dto.UpdateMemberProfileCommand;
 import com.baro.member.presentation.dto.UpdateMemberProfileRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -39,4 +40,11 @@ public class MemberController {
         return ResponseEntity.noContent().build();
     }
 
+    @DeleteMapping("/image")
+    public ResponseEntity<Void> deleteProfileImage(
+            AuthMember authMember
+    ) {
+        memberService.deleteProfileImage(authMember.id());
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/test/java/com/baro/common/acceptance/member/MemberAcceptanceSteps.java
+++ b/src/test/java/com/baro/common/acceptance/member/MemberAcceptanceSteps.java
@@ -93,4 +93,18 @@ public class MemberAcceptanceSteps {
                 .then().log().all()
                 .extract();
     }
+
+    public static ExtractableResponse<Response> 프로필_이미지_삭제_요청(Token 토큰) {
+        return RestAssured.given(requestSpec).log().all()
+                .filter(document(DEFAULT_REST_DOCS_PATH,
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("인증 토큰")
+                        )
+                ))
+                .contentType("application/json")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + 토큰.accessToken())
+                .when().delete("/members/image")
+                .then().log().all()
+                .extract();
+    }
 }

--- a/src/test/java/com/baro/common/fake/FakeImageStorageClient.java
+++ b/src/test/java/com/baro/common/fake/FakeImageStorageClient.java
@@ -1,0 +1,23 @@
+package com.baro.common.fake;
+
+import com.baro.common.image.ImageStorageClient;
+import com.baro.common.image.dto.ImageUploadResult;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.web.multipart.MultipartFile;
+
+public class FakeImageStorageClient implements ImageStorageClient {
+
+    private final Map<String, MultipartFile> storage = new ConcurrentHashMap<>();
+
+    @Override
+    public ImageUploadResult upload(MultipartFile file) {
+        storage.put(file.getOriginalFilename(), file);
+        return new ImageUploadResult(file.getOriginalFilename());
+    }
+
+    @Override
+    public void delete(String key) {
+        storage.remove(key);
+    }
+}

--- a/src/test/java/com/baro/member/fake/FakeMemberRepository.java
+++ b/src/test/java/com/baro/member/fake/FakeMemberRepository.java
@@ -32,6 +32,7 @@ public class FakeMemberRepository implements MemberRepository {
                     member.getName(),
                     member.getEmail(),
                     member.getNickname().value(),
+                    member.getProfileImageUrl(),
                     member.getOAuthId(),
                     member.getOAuthServiceType()
             );

--- a/src/test/java/com/baro/member/fixture/MemberFixture.java
+++ b/src/test/java/com/baro/member/fixture/MemberFixture.java
@@ -13,4 +13,15 @@ public class MemberFixture {
                 .oAuthServiceType("oAuthServiceType")
                 .build();
     }
+
+    public static Member memberWithNicknameAndProfileImage(String nickname, String profileImageUrl) {
+        return Member.builder()
+                .name("name")
+                .email("email")
+                .nickname(nickname)
+                .oAuthId("oAuthId" + nickname)
+                .profileImageUrl(profileImageUrl)
+                .oAuthServiceType("oAuthServiceType")
+                .build();
+    }
 }

--- a/src/test/java/com/baro/member/presentation/MemberApiTest.java
+++ b/src/test/java/com/baro/member/presentation/MemberApiTest.java
@@ -13,6 +13,7 @@ import static com.baro.common.acceptance.member.MemberAcceptanceSteps.빈_닉네
 import static com.baro.common.acceptance.member.MemberAcceptanceSteps.잘못된_내_프로필_수정_요청;
 import static com.baro.common.acceptance.member.MemberAcceptanceSteps.잘못된_프로필_조회_요청;
 import static com.baro.common.acceptance.member.MemberAcceptanceSteps.프로필_수정_바디;
+import static com.baro.common.acceptance.member.MemberAcceptanceSteps.프로필_이미지_삭제_요청;
 import static org.mockito.BDDMockito.given;
 
 import com.baro.auth.application.TokenTranslator;
@@ -120,5 +121,19 @@ public class MemberApiTest extends RestApiTest {
 
     private void 멤버가_존재하지_않는다(Token 토큰) {
         given(tokenTranslator.decodeAccessToken("Bearer " + 토큰.accessToken())).willReturn(999L);
+    }
+
+    //TODO : 프로필 이미지 등록 API 개발 후 추가
+
+    @Test
+    void 프로필_이미지가_없는_경우_이미지_삭제시_예외_발생() {
+        // given
+        var 토큰 = 로그인(태연());
+
+        // when
+        var 응답 = 프로필_이미지_삭제_요청(토큰);
+
+        // then
+        응답값을_검증한다(응답, 잘못된_요청);
     }
 }


### PR DESCRIPTION
## 관련된 이슈
Bar-222

## 작업 사항
- 프로필 이미지 삭제 API 추가
- 프로필 이미지가 기본 이미지인 경우에 삭제 요청시 예외 반환

## 기타
- Acceptance test경우 프로필 이미지 등록 api가 요구되어서 TODO로 남겨두었습니다. `BAR-221` 작업시 추가해두겠습니다!
