### PR TITLE
feat: 프로필 이미지 수정 API

### DIFF
--- a/src/main/java/com/baro/member/application/MemberService.java
+++ b/src/main/java/com/baro/member/application/MemberService.java
@@ -1,8 +1,10 @@
 package com.baro.member.application;
 
 import com.baro.common.image.ImageStorageClient;
+import com.baro.common.image.dto.ImageUploadResult;
 import com.baro.member.application.dto.GetMemberProfileResult;
 import com.baro.member.application.dto.UpdateMemberProfileCommand;
+import com.baro.member.application.dto.UpdateProfileImageCommand;
 import com.baro.member.domain.Member;
 import com.baro.member.domain.MemberRepository;
 import com.baro.member.exception.MemberException;
@@ -42,5 +44,14 @@ public class MemberService {
         String profileImageKey = member.getProfileImageUrl();
         member.deleteProfileImage();
         imageStorageClient.delete(profileImageKey);
+    }
+
+    public void updateProfileImage(UpdateProfileImageCommand command) {
+        Member member = memberRepository.getById(command.id());
+        if (!member.isDefaultImage()) {
+            imageStorageClient.delete(member.getProfileImageUrl());
+        }
+        ImageUploadResult imageUploadResult = imageStorageClient.upload(command.image());
+        member.updateProfileImage(imageUploadResult.key());
     }
 }

--- a/src/main/java/com/baro/member/application/dto/UpdateProfileImageCommand.java
+++ b/src/main/java/com/baro/member/application/dto/UpdateProfileImageCommand.java
@@ -1,0 +1,9 @@
+package com.baro.member.application.dto;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public record UpdateProfileImageCommand(
+        Long id,
+        MultipartFile image
+) {
+}

--- a/src/main/java/com/baro/member/domain/Member.java
+++ b/src/main/java/com/baro/member/domain/Member.java
@@ -85,9 +85,17 @@ public class Member extends BaseEntity {
     }
 
     public void deleteProfileImage() {
-        if (Objects.isNull(this.profileImageUrl)) {
+        if (isDefaultImage()) {
             throw new MemberException(MemberExceptionType.NOT_EXIST_PROFILE_IMAGE);
         }
         this.profileImageUrl = null;
+    }
+
+    public boolean isDefaultImage() {
+        return Objects.isNull(this.profileImageUrl);
+    }
+
+    public void updateProfileImage(String profileImageUrl) {
+        this.profileImageUrl = profileImageUrl;
     }
 }

--- a/src/main/java/com/baro/member/presentation/MemberController.java
+++ b/src/main/java/com/baro/member/presentation/MemberController.java
@@ -4,6 +4,7 @@ import com.baro.auth.domain.AuthMember;
 import com.baro.member.application.MemberService;
 import com.baro.member.application.dto.GetMemberProfileResult;
 import com.baro.member.application.dto.UpdateMemberProfileCommand;
+import com.baro.member.application.dto.UpdateProfileImageCommand;
 import com.baro.member.presentation.dto.UpdateMemberProfileRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RequiredArgsConstructor
 @RequestMapping("/members")
@@ -45,6 +47,16 @@ public class MemberController {
             AuthMember authMember
     ) {
         memberService.deleteProfileImage(authMember.id());
+        return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping("/image")
+    public ResponseEntity<Void> updateProfileImage(
+            AuthMember authMember,
+            @RequestBody MultipartFile profileImage
+    ) {
+        UpdateProfileImageCommand command = new UpdateProfileImageCommand(authMember.id(), profileImage);
+        memberService.updateProfileImage(command);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/test/java/com/baro/member/presentation/MemberApiTest.java
+++ b/src/test/java/com/baro/member/presentation/MemberApiTest.java
@@ -13,16 +13,23 @@ import static com.baro.common.acceptance.member.MemberAcceptanceSteps.빈_닉네
 import static com.baro.common.acceptance.member.MemberAcceptanceSteps.잘못된_내_프로필_수정_요청;
 import static com.baro.common.acceptance.member.MemberAcceptanceSteps.잘못된_프로필_조회_요청;
 import static com.baro.common.acceptance.member.MemberAcceptanceSteps.프로필_수정_바디;
+import static com.baro.common.acceptance.member.MemberAcceptanceSteps.프로필_이미지;
 import static com.baro.common.acceptance.member.MemberAcceptanceSteps.프로필_이미지_삭제_요청;
+import static com.baro.common.acceptance.member.MemberAcceptanceSteps.프로필_이미지_수정_요청;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
 import com.baro.auth.application.TokenTranslator;
 import com.baro.auth.domain.Token;
 import com.baro.common.RestApiTest;
+import com.baro.common.image.ImageStorageClient;
+import com.baro.common.image.dto.ImageUploadResult;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.web.multipart.MultipartFile;
 
 @DisplayNameGeneration(ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
@@ -30,6 +37,9 @@ public class MemberApiTest extends RestApiTest {
 
     @SpyBean
     private TokenTranslator tokenTranslator;
+
+    @MockBean
+    private ImageStorageClient imageStorageClient;
 
     @Test
     void 내_프로필_정보를_조회_한다() {
@@ -135,5 +145,22 @@ public class MemberApiTest extends RestApiTest {
 
         // then
         응답값을_검증한다(응답, 잘못된_요청);
+    }
+
+    @Test
+    void 프로필_이미지를_수정한다() {
+        // given
+        var 토큰 = 로그인(태연());
+        이미지를_등록한다(프로필_이미지);
+
+        // when
+        var 응답 = 프로필_이미지_수정_요청(토큰, 프로필_이미지);
+
+        // then
+        응답값을_검증한다(응답, 응답값_없음);
+    }
+
+    private void 이미지를_등록한다(MultipartFile 이미지) {
+        given(imageStorageClient.upload(any())).willReturn(new ImageUploadResult(이미지.getOriginalFilename()));
     }
 }

--- a/src/test/java/com/baro/member/presentation/MemberApiTest.java
+++ b/src/test/java/com/baro/member/presentation/MemberApiTest.java
@@ -18,6 +18,7 @@ import static com.baro.common.acceptance.member.MemberAcceptanceSteps.프로필_
 import static com.baro.common.acceptance.member.MemberAcceptanceSteps.프로필_이미지_수정_요청;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
 
 import com.baro.auth.application.TokenTranslator;
 import com.baro.auth.domain.Token;
@@ -133,7 +134,20 @@ public class MemberApiTest extends RestApiTest {
         given(tokenTranslator.decodeAccessToken("Bearer " + 토큰.accessToken())).willReturn(999L);
     }
 
-    //TODO : 프로필 이미지 등록 API 개발 후 추가
+    @Test
+    void 프로필_이미지를_삭제한다() {
+        // given
+        var 토큰 = 로그인(태연());
+        이미지가_등록된다(프로필_이미지);
+        프로필_이미지_수정_요청(토큰, 프로필_이미지);
+        이미지가_삭제된다();
+
+        // when
+        var 응답 = 프로필_이미지_삭제_요청(토큰);
+
+        // then
+        응답값을_검증한다(응답, 응답값_없음);
+    }
 
     @Test
     void 프로필_이미지가_없는_경우_이미지_삭제시_예외_발생() {
@@ -151,7 +165,7 @@ public class MemberApiTest extends RestApiTest {
     void 프로필_이미지를_수정한다() {
         // given
         var 토큰 = 로그인(태연());
-        이미지를_등록한다(프로필_이미지);
+        이미지가_등록된다(프로필_이미지);
 
         // when
         var 응답 = 프로필_이미지_수정_요청(토큰, 프로필_이미지);
@@ -160,7 +174,11 @@ public class MemberApiTest extends RestApiTest {
         응답값을_검증한다(응답, 응답값_없음);
     }
 
-    private void 이미지를_등록한다(MultipartFile 이미지) {
+    private void 이미지가_등록된다(MultipartFile 이미지) {
         given(imageStorageClient.upload(any())).willReturn(new ImageUploadResult(이미지.getOriginalFilename()));
+    }
+
+    private void 이미지가_삭제된다() {
+        doNothing().when(imageStorageClient).delete(any());
     }
 }


### PR DESCRIPTION
## 관련된 이슈
Bar-221

## 작업 사항
<!-- 구현한 내용에 대한 설명-->
- 프로필 이미지 수정  API 추가
기본 프로필인 경우 이미지 추가, 이미 프로필 이미지가 존재하는 경우 삭제 후 반영

## 기타
- #53 에서 누락된 테스트 추가 67a5397c62d14d8bc8ea633936a883bb4fa61976
