### PR TITLE
refactor: 맞춤법 검사 결과 저장 스펙 수정

### DIFF
--- a/src/main/java/com/baro/memo/application/TemporalMemoService.java
+++ b/src/main/java/com/baro/memo/application/TemporalMemoService.java
@@ -107,7 +107,7 @@ public class TemporalMemoService {
         MemoFolder memoFolder = memoFolderRepository.getById(command.memoFolderId());
         memoFolder.matchOwner(member.getId());
 
-        Archive archive = archiveRepository.save(new Archive(member, memoFolder, temporalMemo.getContent()));
+        Archive archive = archiveRepository.save(new Archive(member, memoFolder, temporalMemo.getArchivingContent()));
         temporalMemo.archived(archive);
         return ArchiveTemporalMemoResult.from(archive);
     }

--- a/src/main/java/com/baro/memo/application/TemporalMemoService.java
+++ b/src/main/java/com/baro/memo/application/TemporalMemoService.java
@@ -63,7 +63,7 @@ public class TemporalMemoService {
     public void applyCorrection(ApplyCorrectionCommand command) {
         TemporalMemo temporalMemo = temporalMemoRepository.getById(command.temporalMemoId());
         temporalMemo.matchOwner(command.memberId());
-        temporalMemo.applyCorrection(MemoContent.from(command.contents()));
+        temporalMemo.applyCorrection(MemoContent.from(command.correctionContent()), command.styledCorrectionContent());
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/baro/memo/application/dto/ApplyCorrectionCommand.java
+++ b/src/main/java/com/baro/memo/application/dto/ApplyCorrectionCommand.java
@@ -3,6 +3,7 @@ package com.baro.memo.application.dto;
 public record ApplyCorrectionCommand(
         Long memberId,
         Long temporalMemoId,
-        String contents
+        String correctionContent,
+        String styledCorrectionContent
 ) {
 }

--- a/src/main/java/com/baro/memo/application/dto/FindTemporalMemoResult.java
+++ b/src/main/java/com/baro/memo/application/dto/FindTemporalMemoResult.java
@@ -6,7 +6,7 @@ import java.time.LocalDateTime;
 public record FindTemporalMemoResult(
         Long id,
         String content,
-        String correctionContent,
+        String styledCorrectionContent,
         Boolean isCorrected,
         Boolean isArchived,
         LocalDateTime createdAt
@@ -16,7 +16,7 @@ public record FindTemporalMemoResult(
         return new FindTemporalMemoResult(
                 temporalMemo.getId(),
                 temporalMemo.getContent().value(),
-                temporalMemo.getCorrectionContent() == null ? null : temporalMemo.getCorrectionContent().value(),
+                temporalMemo.getStyledCorrectionContent() == null ? null : temporalMemo.getStyledCorrectionContent(),
                 temporalMemo.isCorrected(),
                 temporalMemo.isArchived(),
                 temporalMemo.getCreatedAt()

--- a/src/main/java/com/baro/memo/domain/TemporalMemo.java
+++ b/src/main/java/com/baro/memo/domain/TemporalMemo.java
@@ -41,9 +41,11 @@ public class TemporalMemo extends BaseEntity {
     private MemoContent content;
 
     @Embedded
-    @Column(columnDefinition = "TEXT")
     @AttributeOverride(name = "content", column = @Column(name = "correction_content"))
     private MemoContent correctionContent;
+
+    @Column(columnDefinition = "TEXT")
+    private String styledCorrectionContent;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "archive_id", nullable = true, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
@@ -90,11 +92,12 @@ public class TemporalMemo extends BaseEntity {
         this.archive = archive;
     }
 
-    public void applyCorrection(MemoContent correctionContent) {
+    public void applyCorrection(MemoContent correctionContent, String styledCorrectionContent) {
         if (isCorrected()) {
             throw new TemporalMemoException(TemporalMemoExceptionType.ALREADY_CORRECTED);
         }
         this.correctionContent = correctionContent;
+        this.styledCorrectionContent = styledCorrectionContent;
     }
 
     public boolean isArchived() {

--- a/src/main/java/com/baro/memo/presentation/TemporalMemoController.java
+++ b/src/main/java/com/baro/memo/presentation/TemporalMemoController.java
@@ -80,7 +80,7 @@ public class TemporalMemoController {
             @PathVariable Long temporalMemoId
     ) {
         ApplyCorrectionCommand command = new ApplyCorrectionCommand(authMember.id(), temporalMemoId,
-                request.content());
+                request.correctionContent(), request.styledCorrectionContent());
         temporalMemoService.applyCorrection(command);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/baro/memo/presentation/dto/ApplyCorrectionRequest.java
+++ b/src/main/java/com/baro/memo/presentation/dto/ApplyCorrectionRequest.java
@@ -1,6 +1,7 @@
 package com.baro.memo.presentation.dto;
 
 public record ApplyCorrectionRequest(
-        String content
+        String correctionContent,
+        String styledCorrectionContent
 ) {
 }

--- a/src/test/java/com/baro/common/acceptance/memo/TemporalMemoAcceptanceSteps.java
+++ b/src/test/java/com/baro/common/acceptance/memo/TemporalMemoAcceptanceSteps.java
@@ -171,7 +171,7 @@ public class TemporalMemoAcceptanceSteps {
                                 headerWithName(HttpHeaders.AUTHORIZATION).description("인증 토큰")
                         ),
                         requestFields(
-                                fieldWithPath("correctionContent").description("맞춤법 검사 결과"),
+                                fieldWithPath("styledCorrectionContent").description("맞춤법 검사 결과"),
                                 fieldWithPath("styledCorrectionContent").description("스타일 포함 맞춤법 검사 결과")
                         ))
                 ).contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -192,7 +192,7 @@ public class TemporalMemoAcceptanceSteps {
                                 headerWithName(HttpHeaders.AUTHORIZATION).description("인증 토큰")
                         ),
                         requestFields(
-                                fieldWithPath("correctionContent").description("맞춤법 검사 결과"),
+                                fieldWithPath("styledCorrectionContent").description("맞춤법 검사 결과"),
                                 fieldWithPath("styledCorrectionContent").description("스타일 포함 맞춤법 검사 결과")
                         ),
                         responseFields(예외_응답()))
@@ -218,7 +218,8 @@ public class TemporalMemoAcceptanceSteps {
                                 fieldWithPath("[].temporalMemos").description("끄적이는 메모 목록"),
                                 fieldWithPath("[].temporalMemos[].id").description("끄적이는 메모 ID"),
                                 fieldWithPath("[].temporalMemos[].content").description("끄적이는 메모 내용"),
-                                fieldWithPath("[].temporalMemos[].correctionContent").description("끄적이는 메모 맞춤법 검사 결과"),
+                                fieldWithPath("[].temporalMemos[].styledCorrectionContent").description(
+                                        "끄적이는 메모 맞춤법 검사 결과"),
                                 fieldWithPath("[].temporalMemos[].isCorrected").description("끄적이는 메모 맞춤법 검사 결과 반영 여부"),
                                 fieldWithPath("[].temporalMemos[].isArchived").description("끄적이는 메모 아카이브 여부"),
                                 fieldWithPath("[].temporalMemos[].createdAt").description("끄적이는 메모 생성 시간")

--- a/src/test/java/com/baro/common/acceptance/memo/TemporalMemoAcceptanceSteps.java
+++ b/src/test/java/com/baro/common/acceptance/memo/TemporalMemoAcceptanceSteps.java
@@ -33,8 +33,9 @@ public class TemporalMemoAcceptanceSteps {
     public static final SaveTemporalMemoRequest 크기_초과_끄적이는_메모_작성_바디 = new SaveTemporalMemoRequest(크기_초과_컨텐츠);
     public static final UpdateTemporalMemoRequest 끄적이는_메모_수정_바디 = new UpdateTemporalMemoRequest("끄적이는 메모 수정 컨텐츠");
     public static final UpdateTemporalMemoRequest 크기_초과_끄적이는_메모_수정_바디 = new UpdateTemporalMemoRequest(크기_초과_컨텐츠);
-    public static final ApplyCorrectionRequest 맞춤법_검사_결과_반영_바디 = new ApplyCorrectionRequest("맞춤법 검사 결과");
-    public static final ApplyCorrectionRequest 크기_초과_맞춤법_검사_결과_반영_바디 = new ApplyCorrectionRequest(크기_초과_컨텐츠);
+    public static final ApplyCorrectionRequest 맞춤법_검사_결과_반영_바디 = new ApplyCorrectionRequest("맞춤법 검사 결과",
+            "<p>맞춤법 검사 결과</p>");
+    public static final ApplyCorrectionRequest 크기_초과_맞춤법_검사_결과_반영_바디 = new ApplyCorrectionRequest(크기_초과_컨텐츠, 크기_초과_컨텐츠);
 
     public static ArchiveTemporalMemoRequest 메모_아카이브_요청_바디(Long 메모_폴더_ID) {
         return new ArchiveTemporalMemoRequest(메모_폴더_ID);
@@ -170,7 +171,8 @@ public class TemporalMemoAcceptanceSteps {
                                 headerWithName(HttpHeaders.AUTHORIZATION).description("인증 토큰")
                         ),
                         requestFields(
-                                fieldWithPath("content").description("맞춤법 검사 결과")
+                                fieldWithPath("correctionContent").description("맞춤법 검사 결과"),
+                                fieldWithPath("styledCorrectionContent").description("스타일 포함 맞춤법 검사 결과")
                         ))
                 ).contentType(MediaType.APPLICATION_JSON_VALUE)
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + 토큰.accessToken()).body(바디)
@@ -190,7 +192,8 @@ public class TemporalMemoAcceptanceSteps {
                                 headerWithName(HttpHeaders.AUTHORIZATION).description("인증 토큰")
                         ),
                         requestFields(
-                                fieldWithPath("content").description("맞춤법 검사 결과")
+                                fieldWithPath("correctionContent").description("맞춤법 검사 결과"),
+                                fieldWithPath("styledCorrectionContent").description("스타일 포함 맞춤법 검사 결과")
                         ),
                         responseFields(예외_응답()))
                 ).contentType(MediaType.APPLICATION_JSON_VALUE)

--- a/src/test/java/com/baro/common/acceptance/memo/TemporalMemoAcceptanceSteps.java
+++ b/src/test/java/com/baro/common/acceptance/memo/TemporalMemoAcceptanceSteps.java
@@ -171,7 +171,7 @@ public class TemporalMemoAcceptanceSteps {
                                 headerWithName(HttpHeaders.AUTHORIZATION).description("인증 토큰")
                         ),
                         requestFields(
-                                fieldWithPath("styledCorrectionContent").description("맞춤법 검사 결과"),
+                                fieldWithPath("correctionContent").description("맞춤법 검사 결과"),
                                 fieldWithPath("styledCorrectionContent").description("스타일 포함 맞춤법 검사 결과")
                         ))
                 ).contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -192,7 +192,7 @@ public class TemporalMemoAcceptanceSteps {
                                 headerWithName(HttpHeaders.AUTHORIZATION).description("인증 토큰")
                         ),
                         requestFields(
-                                fieldWithPath("styledCorrectionContent").description("맞춤법 검사 결과"),
+                                fieldWithPath("correctionContent").description("맞춤법 검사 결과"),
                                 fieldWithPath("styledCorrectionContent").description("스타일 포함 맞춤법 검사 결과")
                         ),
                         responseFields(예외_응답()))

--- a/src/test/java/com/baro/memo/application/TemporalMemoServiceTest.java
+++ b/src/test/java/com/baro/memo/application/TemporalMemoServiceTest.java
@@ -196,8 +196,9 @@ class TemporalMemoServiceTest {
         Member member = memberRepository.save(MemberFixture.memberWithNickname("nickname1"));
         TemporalMemo temporalMemo = temporalMemoRepository.save(TemporalMemo.of(member, "testContent"));
         String correctionContent = "correctedContent";
+        String styledCorrectionContent = "<span>correctedContent</span>";
         ApplyCorrectionCommand command = new ApplyCorrectionCommand(member.getId(), temporalMemo.getId(),
-                correctionContent);
+                correctionContent, styledCorrectionContent);
 
         // when
         temporalMemoService.applyCorrection(command);
@@ -218,8 +219,9 @@ class TemporalMemoServiceTest {
         Member otherMember = memberRepository.save(MemberFixture.memberWithNickname("nickname2"));
         TemporalMemo temporalMemo = temporalMemoRepository.save(TemporalMemo.of(member, "testContent"));
         String correctionContent = "correctedContent";
+        String styledCorrectionContent = "<span>correctedContent</span>";
         ApplyCorrectionCommand command = new ApplyCorrectionCommand(otherMember.getId(), temporalMemo.getId(),
-                correctionContent);
+                correctionContent, styledCorrectionContent);
 
         // when & then
         assertThatThrownBy(() -> temporalMemoService.applyCorrection(command))
@@ -234,8 +236,9 @@ class TemporalMemoServiceTest {
         Member member = memberRepository.save(MemberFixture.memberWithNickname("nickname1"));
         Long notExistTemporalMemoId = 999L;
         String correctionContent = "correctedContent";
+        String styledCorrectionContent = "<span>correctedContent</span>";
         ApplyCorrectionCommand command = new ApplyCorrectionCommand(member.getId(), notExistTemporalMemoId,
-                correctionContent);
+                correctionContent, styledCorrectionContent);
 
         // when & then
         assertThatThrownBy(() -> temporalMemoService.applyCorrection(command))
@@ -249,10 +252,11 @@ class TemporalMemoServiceTest {
         // given
         Member member = memberRepository.save(MemberFixture.memberWithNickname("nickname1"));
         TemporalMemo temporalMemo = temporalMemoRepository.save(TemporalMemo.of(member, "testContent"));
-        temporalMemo.applyCorrection(MemoContent.from("correctedContent"));
+        String styledCorrectionContent = "<span>correctedContent</span>";
+        temporalMemo.applyCorrection(MemoContent.from("correctedContent"), styledCorrectionContent);
         String correctionContent = "correctedContent";
         ApplyCorrectionCommand command = new ApplyCorrectionCommand(member.getId(), temporalMemo.getId(),
-                correctionContent);
+                correctionContent, styledCorrectionContent);
 
         // when & then
         assertThatThrownBy(() -> temporalMemoService.applyCorrection(command))

--- a/src/test/java/com/baro/memo/domain/TemporalMemoTest.java
+++ b/src/test/java/com/baro/memo/domain/TemporalMemoTest.java
@@ -108,9 +108,10 @@ class TemporalMemoTest {
         // given
         TemporalMemo temporalMemo = TemporalMemo.of(MemberFixture.memberWithNickname("바로"), "메모");
         MemoContent correctionContent = MemoContent.from("메모");
+        String styledCorrectionContent = "<strong> 메모 </strong>";
 
         // when
-        temporalMemo.applyCorrection(correctionContent);
+        temporalMemo.applyCorrection(correctionContent, styledCorrectionContent);
 
         // then
         assertAll(
@@ -124,10 +125,11 @@ class TemporalMemoTest {
         // given
         TemporalMemo temporalMemo = TemporalMemo.of(MemberFixture.memberWithNickname("바로"), "메모");
         MemoContent correctionContent = MemoContent.from("메모");
-        temporalMemo.applyCorrection(correctionContent);
+        String styledCorrectionContent = "<strong> 메모 </strong>";
+        temporalMemo.applyCorrection(correctionContent, styledCorrectionContent);
 
         // when & then
-        assertThatCode(() -> temporalMemo.applyCorrection(correctionContent))
+        assertThatCode(() -> temporalMemo.applyCorrection(correctionContent, styledCorrectionContent))
                 .isInstanceOf(TemporalMemoException.class)
                 .extracting("exceptionType")
                 .isEqualTo(TemporalMemoExceptionType.ALREADY_CORRECTED);


### PR DESCRIPTION
## 관련된 이슈
Bar-228

## 작업 사항
<!-- 구현한 내용에 대한 설명-->
- TemporalMemo에 `styledCorrectionContent` 추가
- 맞춤법 검사 결과 반영 API request에 `styledCorrectionContent` 필드 추가
